### PR TITLE
Issue 62: Store LSSS requests in an internal queue

### DIFF
--- a/src/main/java/edu/tamu/app/cache/service/ActiveSprintsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/ActiveSprintsScheduledCacheService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -77,14 +78,16 @@ public class ActiveSprintsScheduledCacheService extends AbstractProductScheduled
 
     private List<Sprint> fetchActiveSprints(Product product) {
         List<Sprint> activeSprints = new ArrayList<Sprint>();
-        Optional<RemoteProductManager> remoteProductManager = Optional.ofNullable(product.getRemoteProductManager());
-        if (remoteProductManager.isPresent()) {
-            RemoteProductManagerBean remoteProductManagerBean = (RemoteProductManagerBean) managementBeanRegistry.getService(remoteProductManager.get().getName());
-            try {
-                activeSprints.addAll(remoteProductManagerBean.getActiveSprintsByProductId(product.getScopeId()));
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        Optional<List<Pair<String, RemoteProductManager>>> remoteProducts = Optional.ofNullable(product.getRemoteProducts());
+        if (remoteProducts.isPresent()) {
+            remoteProducts.get().forEach(rp -> {
+                RemoteProductManagerBean remoteProductManagerBean = (RemoteProductManagerBean) managementBeanRegistry.getService(rp.getRight().getName());
+                try {
+                    activeSprints.addAll(remoteProductManagerBean.getActiveSprintsByProductId(rp.getLeft()));
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            });
         }
         return activeSprints;
     }

--- a/src/main/java/edu/tamu/app/cache/service/ActiveSprintsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/ActiveSprintsScheduledCacheService.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,7 +15,7 @@ import org.springframework.stereotype.Service;
 import edu.tamu.app.cache.ActiveSprintsCache;
 import edu.tamu.app.cache.model.Sprint;
 import edu.tamu.app.model.Product;
-import edu.tamu.app.model.RemoteProductManager;
+import edu.tamu.app.model.RemoteProductInfo;
 import edu.tamu.app.model.repo.ProductRepo;
 import edu.tamu.app.service.manager.RemoteProductManagerBean;
 import edu.tamu.weaver.response.ApiResponse;
@@ -78,12 +77,12 @@ public class ActiveSprintsScheduledCacheService extends AbstractProductScheduled
 
     private List<Sprint> fetchActiveSprints(Product product) {
         List<Sprint> activeSprints = new ArrayList<Sprint>();
-        Optional<List<Pair<String, RemoteProductManager>>> remoteProducts = Optional.ofNullable(product.getRemoteProducts());
+        Optional<List<RemoteProductInfo>> remoteProducts = Optional.ofNullable(product.getRemoteProducts());
         if (remoteProducts.isPresent()) {
             remoteProducts.get().forEach(rp -> {
-                RemoteProductManagerBean remoteProductManagerBean = (RemoteProductManagerBean) managementBeanRegistry.getService(rp.getRight().getName());
+                RemoteProductManagerBean remoteProductManagerBean = (RemoteProductManagerBean) managementBeanRegistry.getService(rp.getRemoteProductManager().getName());
                 try {
-                    activeSprints.addAll(remoteProductManagerBean.getActiveSprintsByProductId(rp.getLeft()));
+                    activeSprints.addAll(remoteProductManagerBean.getActiveSprintsByProductId(rp.getScopeId()));
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
@@ -7,17 +7,18 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import edu.tamu.app.cache.ProductsStatsCache;
 import edu.tamu.app.cache.model.ProductStats;
 import edu.tamu.app.cache.model.RemoteProduct;
 import edu.tamu.app.model.Product;
 import edu.tamu.app.model.RemoteProductManager;
+import edu.tamu.app.model.RemoteProductInfo;
 import edu.tamu.app.model.repo.ProductRepo;
 import edu.tamu.weaver.response.ApiResponse;
 
@@ -73,7 +74,8 @@ public class ProductsStatsScheduledCacheService extends AbstractProductScheduled
     }
 
     public void removeProduct(Product product) {
-        List<ProductStats> productsStats = get().stream().filter(p -> !p.getId().equals(product.getId().toString())).collect(Collectors.toList());
+        List<ProductStats> productsStats = get().stream().filter(p -> !p.getId().equals(product.getId().toString()))
+                .collect(Collectors.toList());
         set(productsStats);
         broadcast();
     }
@@ -86,10 +88,10 @@ public class ProductsStatsScheduledCacheService extends AbstractProductScheduled
         int featureCount = 0;
         int defectCount = 0;
 
-        List<Pair<String, RemoteProductManager>> remoteProducts = product.getRemoteProducts();
-        for (Pair<String, RemoteProductManager> rp : remoteProducts) {
-            Optional<RemoteProductManager> remoteProductManager = Optional.ofNullable(rp.getRight());
-            Optional<String> scopeId = Optional.ofNullable(rp.getLeft());
+        List<RemoteProductInfo> remoteProducts = product.getRemoteProducts();
+        for (RemoteProductInfo rp : remoteProducts) {
+            Optional<RemoteProductManager> remoteProductManager = Optional.ofNullable(rp.getRemoteProductManager());
+            Optional<String> scopeId = Optional.ofNullable(rp.getScopeId());
             if (remoteProductManager.isPresent() && scopeId.isPresent()) {
                 Optional<RemoteProduct> remoteProduct = remoteProductsScheduledCacheService.getRemoteProduct(remoteProductManager.get().getId(), scopeId.get());
                 if (remoteProduct.isPresent()) {

--- a/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -85,17 +86,18 @@ public class ProductsStatsScheduledCacheService extends AbstractProductScheduled
         int featureCount = 0;
         int defectCount = 0;
 
-        // NOTE: if and when product can be associated to multiple remote products, loop here
-
-        Optional<RemoteProductManager> remoteProductManager = Optional.ofNullable(product.getRemoteProductManager());
-        Optional<String> scopeId = Optional.ofNullable(product.getScopeId());
-        if (remoteProductManager.isPresent() && scopeId.isPresent()) {
-            Optional<RemoteProduct> remoteProduct = remoteProductsScheduledCacheService.getRemoteProduct(remoteProductManager.get().getId(), scopeId.get());
-            if (remoteProduct.isPresent()) {
-                requestCount += remoteProduct.get().getRequestCount();
-                issueCount += remoteProduct.get().getIssueCount();
-                featureCount += remoteProduct.get().getFeatureCount();
-                defectCount += remoteProduct.get().getDefectCount();
+        List<Pair<String, RemoteProductManager>> remoteProducts = product.getRemoteProducts();
+        for (Pair<String, RemoteProductManager> rp : remoteProducts) {
+            Optional<RemoteProductManager> remoteProductManager = Optional.ofNullable(rp.getRight());
+            Optional<String> scopeId = Optional.ofNullable(rp.getLeft());
+            if (remoteProductManager.isPresent() && scopeId.isPresent()) {
+                Optional<RemoteProduct> remoteProduct = remoteProductsScheduledCacheService.getRemoteProduct(remoteProductManager.get().getId(), scopeId.get());
+                if (remoteProduct.isPresent()) {
+                    requestCount += remoteProduct.get().getRequestCount();
+                    issueCount += remoteProduct.get().getIssueCount();
+                    featureCount += remoteProduct.get().getFeatureCount();
+                    defectCount += remoteProduct.get().getDefectCount();
+                }
             }
         }
 

--- a/src/main/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheService.java
@@ -43,17 +43,17 @@ public class RemoteProductsScheduledCacheService extends AbstractScheduledCacheS
 
     public void update() {
         logger.info("Caching remote products...");
-        Map<Long, List<RemoteProduct>> remoteproducts = new HashMap<Long, List<RemoteProduct>>();
-        for (RemoteProductManager remoteproductManager : remoteProductManagerRepo.findAll()) {
-            RemoteProductManagerBean remoteproductManagerBean = (RemoteProductManagerBean) managementBeanRegistry
-                    .getService(remoteproductManager.getName());
+        Map<Long, List<RemoteProduct>> remoteProducts = new HashMap<Long, List<RemoteProduct>>();
+        for (RemoteProductManager remoteProductManager : remoteProductManagerRepo.findAll()) {
+            RemoteProductManagerBean remoteProductManagerBean = (RemoteProductManagerBean) managementBeanRegistry
+                    .getService(remoteProductManager.getName());
             try {
-                remoteproducts.put(remoteproductManager.getId(), remoteproductManagerBean.getRemoteProduct());
+                remoteProducts.put(remoteProductManager.getId(), remoteProductManagerBean.getRemoteProduct());
             } catch (Exception e) {
                 e.printStackTrace();
             }
         }
-        set(remoteproducts);
+        set(remoteProducts);
         logger.info("Finished caching remote products");
     }
 
@@ -62,18 +62,18 @@ public class RemoteProductsScheduledCacheService extends AbstractScheduledCacheS
         simpMessagingTemplate.convertAndSend("/channel/products/remote", new ApiResponse(SUCCESS, get()));
     }
 
-    public Optional<RemoteProduct> getRemoteProduct(Long remoteproductManagerId, String scopeId) {
-        Optional<RemoteProduct> remoteproduct = Optional.empty();
-        Optional<List<RemoteProduct>> remoteproducts = Optional.ofNullable(get().get(remoteproductManagerId));
-        if (remoteproducts.isPresent()) {
-            for (RemoteProduct rp : remoteproducts.get()) {
+    public Optional<RemoteProduct> getRemoteProduct(Long remoteProductManagerId, String scopeId) {
+        Optional<RemoteProduct> remoteProduct = Optional.empty();
+        Optional<List<RemoteProduct>> remoteProducts = Optional.ofNullable(get().get(remoteProductManagerId));
+        if (remoteProducts.isPresent()) {
+            for (RemoteProduct rp : remoteProducts.get()) {
                 if (rp.getId().equals(scopeId)) {
-                    remoteproduct = Optional.of(rp);
+                    remoteProduct = Optional.of(rp);
                     break;
                 }
             }
         }
-        return remoteproduct;
+        return remoteProduct;
     }
 
     @Override

--- a/src/main/java/edu/tamu/app/controller/InternalRequestController.java
+++ b/src/main/java/edu/tamu/app/controller/InternalRequestController.java
@@ -1,0 +1,120 @@
+package edu.tamu.app.controller;
+
+import static edu.tamu.weaver.response.ApiStatus.ERROR;
+import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
+import static edu.tamu.weaver.validation.model.BusinessValidationType.CREATE;
+import static edu.tamu.weaver.validation.model.BusinessValidationType.DELETE;
+import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.tamu.app.model.InternalRequest;
+import edu.tamu.app.model.Product;
+import edu.tamu.app.model.RemoteProductManager;
+import edu.tamu.app.model.repo.InternalRequestRepo;
+import edu.tamu.app.model.repo.ProductRepo;
+import edu.tamu.app.model.request.FeatureRequest;
+import edu.tamu.app.service.manager.RemoteProductManagerBean;
+import edu.tamu.app.service.registry.ManagementBeanRegistry;
+import edu.tamu.weaver.response.ApiResponse;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidatedModel;
+import edu.tamu.weaver.validation.aspect.annotation.WeaverValidation;
+
+@RestController
+@RequestMapping("/internal/request")
+public class InternalRequestController {
+
+    @Autowired
+    private InternalRequestRepo internalRequestRepo;
+
+    @Autowired
+    private ProductRepo productRepo;
+
+    @Autowired
+    private ManagementBeanRegistry managementBeanRegistry;
+
+    @GetMapping
+    @PreAuthorize("hasRole('MANAGER')")
+    public ApiResponse read() {
+        return new ApiResponse(SUCCESS, internalRequestRepo.findAll());
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public ApiResponse read(@PathVariable Long id) {
+        return new ApiResponse(SUCCESS, internalRequestRepo.findOne(id));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('MANAGER')")
+    @WeaverValidation(business = { @WeaverValidation.Business(value = CREATE) })
+    public ApiResponse create(@WeaverValidatedModel InternalRequest internalRequest) {
+        return new ApiResponse(SUCCESS, internalRequestRepo.create(internalRequest));
+    }
+
+    @PutMapping
+    @PreAuthorize("hasRole('MANAGER')")
+    @WeaverValidation(business = { @WeaverValidation.Business(value = UPDATE) })
+    public ApiResponse update(@WeaverValidatedModel InternalRequest internalRequest) {
+        return new ApiResponse(SUCCESS, internalRequestRepo.update(internalRequest));
+    }
+
+    @DeleteMapping
+    @PreAuthorize("hasRole('MANAGER')")
+    @WeaverValidation(business = { @WeaverValidation.Business(value = DELETE) })
+    public ApiResponse delete(@WeaverValidatedModel InternalRequest internalRequest) {
+        internalRequestRepo.delete(internalRequest);
+        return new ApiResponse(SUCCESS);
+    }
+
+    @PutMapping("/push/{requestId}")
+    @PreAuthorize("hasRole('MANAGER')")
+    public ApiResponse push(@PathVariable Long requestId, @RequestBody FeatureRequest featureRequestParam) {
+        Optional<InternalRequest> internalRequest = Optional.ofNullable(internalRequestRepo.findOne(requestId));
+        Optional<Product> product = Optional.ofNullable(productRepo.findOne(featureRequestParam.getProductId()));
+        ApiResponse response;
+
+        if (internalRequest.isPresent() && product.isPresent()) {
+            Optional<RemoteProductManager> remoteProductManager = Optional
+                .ofNullable(product.get().getRemoteProductManager());
+
+            if (remoteProductManager.isPresent()) {
+                FeatureRequest featureRequest = new FeatureRequest(
+                        internalRequest.get().getTitle(), internalRequest.get().getDescription(), product.get().getId(), product.get().getScopeId());
+
+                RemoteProductManagerBean remoteProductManagerBean = 
+                    (RemoteProductManagerBean) managementBeanRegistry.getService(remoteProductManager.get().getName());
+
+                try {
+                    response = new ApiResponse(SUCCESS, remoteProductManagerBean.push(featureRequest));
+                    internalRequestRepo.delete(internalRequest.get());
+                } catch (Exception e) {
+                    response = new ApiResponse(ERROR, "Error pushing request to " + remoteProductManager.get().getName()
+                        + " for product " + product.get().getName() + "!");
+                }
+            } else {
+                response = new ApiResponse(ERROR,
+                    product.get().getName() + " product does not have a Remote Product Manager!");
+            }
+        } else if (internalRequest.isPresent()) {
+            response = new ApiResponse(ERROR, "Product with id " + featureRequestParam.getProductId() + " not found!");
+
+        } else {
+            response = new ApiResponse(ERROR, "Internal Request with id " + requestId + " not found!");
+        }
+
+        return response;
+    }
+
+}

--- a/src/main/java/edu/tamu/app/model/InternalRequest.java
+++ b/src/main/java/edu/tamu/app/model/InternalRequest.java
@@ -1,0 +1,76 @@
+package edu.tamu.app.model;
+
+import java.util.Date;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import edu.tamu.app.model.validation.InternalRequestValidator;
+import edu.tamu.weaver.response.ApiView;
+import edu.tamu.weaver.validation.model.ValidatingBaseEntity;
+
+@Entity
+public class InternalRequest extends ValidatingBaseEntity {
+
+    @NotNull
+    @Column(nullable = false)
+    @JsonView(ApiView.Partial.class)
+    private String title;
+
+    @NotNull
+    @Column(nullable = false)
+    @JsonView(ApiView.Partial.class)
+    private String description;
+
+    @NotNull
+    @Column(nullable = false, updatable = false)
+    @CreationTimestamp
+    private Date createdOn;
+
+    public InternalRequest() {
+        super();
+        this.modelValidator = new InternalRequestValidator();
+    }
+
+    public InternalRequest(String title, String description) {
+        this.title = title;
+        this.description = description;
+        this.createdOn = new Date();
+    }
+
+    public InternalRequest(String title, String description, Date createdOn) {
+        this.title = title;
+        this.description = description;
+        this.createdOn = createdOn;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Date getCreatedOn() {
+        return createdOn;
+    }
+
+    public void setCreatedOn(Date created) {
+        this.createdOn = created;
+    }
+
+}

--- a/src/main/java/edu/tamu/app/model/Product.java
+++ b/src/main/java/edu/tamu/app/model/Product.java
@@ -5,12 +5,21 @@ import static javax.persistence.CascadeType.MERGE;
 import static javax.persistence.CascadeType.REFRESH;
 import static javax.persistence.FetchType.EAGER;
 
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.ManyToOne;
+import javax.swing.RepaintManager;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import org.apache.commons.lang3.tuple.Pair;
+
 import com.fasterxml.jackson.annotation.JsonView;
 
 import edu.tamu.app.model.validation.ProductValidator;
@@ -24,15 +33,19 @@ public class Product extends ValidatingBaseEntity {
     @JsonView(ApiView.Partial.class)
     private String name;
 
-    @JsonInclude(Include.NON_NULL)
-    @Column(nullable = true)
-    @JsonView(ApiView.Partial.class)
-    private String scopeId;
+    // @JsonInclude(Include.NON_NULL)
+    // @Column(nullable = true)
+    // @JsonView(ApiView.Partial.class)
+    // private String scopeId;
 
-    @JsonInclude(Include.NON_NULL)
-    @ManyToOne(fetch = EAGER, cascade = { DETACH, REFRESH, MERGE }, optional = true)
+    // @JsonInclude(Include.NON_NULL)
+    // @ManyToOne(fetch = EAGER, cascade = { DETACH, REFRESH, MERGE }, optional = true)
+    // @JsonView(ApiView.Partial.class)
+    // private RemoteProductManager remoteProductManager;
+
+    @ElementCollection
     @JsonView(ApiView.Partial.class)
-    private RemoteProductManager remoteProductManager;
+    private List<Pair<String, RemoteProductManager>> remoteProducts;
 
     public Product() {
         super();
@@ -44,15 +57,20 @@ public class Product extends ValidatingBaseEntity {
         this.name = name;
     }
 
-    public Product(String name, RemoteProductManager remoteProductManager) {
-        this(name);
-        this.remoteProductManager = remoteProductManager;
+    public Product(String name, List<Pair<String, UUID>> remoteProducts) {
+        this();
+        this.name = name;
     }
 
-    public Product(String name, String scopeId, RemoteProductManager remoteProductManager) {
-        this(name, remoteProductManager);
-        this.scopeId = scopeId;
-    }
+    // public Product(String name, RemoteProductManager remoteProductManager) {
+    //     this(name);
+    //     // this.remoteProductManager = remoteProductManager;
+    // }
+
+    // public Product(String name, String scopeId, RemoteProductManager remoteProductManager) {
+    //     this(name, remoteProductManager);
+    //     // this.scopeId = scopeId;
+    // }
 
     public String getName() {
         return name;
@@ -62,20 +80,39 @@ public class Product extends ValidatingBaseEntity {
         this.name = name;
     }
 
-    public String getScopeId() {
-        return scopeId;
+    public List<Pair<String, RemoteProductManager>> getRemoteProducts() {
+        return remoteProducts;
     }
 
-    public void setScopeId(String scopeId) {
-        this.scopeId = scopeId;
+    public void setRemoteProducts(List<Pair<String, RemoteProductManager>> remoteProducts) {
+        this.remoteProducts = remoteProducts;
     }
 
-    public RemoteProductManager getRemoteProductManager() {
-        return remoteProductManager;
+    public void addRemoteProduct(Pair<String, RemoteProductManager> remoteProduct) {
+        remoteProducts.add(remoteProduct);
     }
 
-    public void setRemoteProductManager(RemoteProductManager remoteProductManager) {
-        this.remoteProductManager = remoteProductManager;
+    public void remoteRemoteProduct(Pair<String, RemoteProductManager> remoteProduct) {
+        remoteProducts = remoteProducts.stream()
+            .filter(rp -> {
+                return !rp.getLeft().equals(remoteProduct.getLeft()) && !rp.getRight().equals(remoteProduct.getRight());
+            }).collect(Collectors.toList());
     }
+
+    // public String getScopeId() {
+    //     return scopeId;
+    // }
+
+    // public void setScopeId(String scopeId) {
+    //     this.scopeId = scopeId;
+    // }
+
+    // public RemoteProductManager getRemoteProductManager() {
+    //     return remoteProductManager;
+    // }
+
+    // public void setRemoteProductManager(RemoteProductManager remoteProductManager) {
+    //     this.remoteProductManager = remoteProductManager;
+    // }
 
 }

--- a/src/main/java/edu/tamu/app/model/Product.java
+++ b/src/main/java/edu/tamu/app/model/Product.java
@@ -1,10 +1,5 @@
 package edu.tamu.app.model;
 
-import static javax.persistence.CascadeType.DETACH;
-import static javax.persistence.CascadeType.MERGE;
-import static javax.persistence.CascadeType.REFRESH;
-import static javax.persistence.FetchType.EAGER;
-
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -12,15 +7,10 @@ import java.util.stream.Collectors;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
-import javax.persistence.ManyToOne;
-import javax.swing.RepaintManager;
-
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-
-import org.apache.commons.lang3.tuple.Pair;
 
 import com.fasterxml.jackson.annotation.JsonView;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import edu.tamu.app.model.validation.ProductValidator;
 import edu.tamu.weaver.response.ApiView;
@@ -33,19 +23,9 @@ public class Product extends ValidatingBaseEntity {
     @JsonView(ApiView.Partial.class)
     private String name;
 
-    // @JsonInclude(Include.NON_NULL)
-    // @Column(nullable = true)
-    // @JsonView(ApiView.Partial.class)
-    // private String scopeId;
-
-    // @JsonInclude(Include.NON_NULL)
-    // @ManyToOne(fetch = EAGER, cascade = { DETACH, REFRESH, MERGE }, optional = true)
-    // @JsonView(ApiView.Partial.class)
-    // private RemoteProductManager remoteProductManager;
-
     @ElementCollection
     @JsonView(ApiView.Partial.class)
-    private List<Pair<String, RemoteProductManager>> remoteProducts;
+    private List<RemoteProductInfo> remoteProducts;
 
     public Product() {
         super();
@@ -62,16 +42,6 @@ public class Product extends ValidatingBaseEntity {
         this.name = name;
     }
 
-    // public Product(String name, RemoteProductManager remoteProductManager) {
-    //     this(name);
-    //     // this.remoteProductManager = remoteProductManager;
-    // }
-
-    // public Product(String name, String scopeId, RemoteProductManager remoteProductManager) {
-    //     this(name, remoteProductManager);
-    //     // this.scopeId = scopeId;
-    // }
-
     public String getName() {
         return name;
     }
@@ -80,39 +50,22 @@ public class Product extends ValidatingBaseEntity {
         this.name = name;
     }
 
-    public List<Pair<String, RemoteProductManager>> getRemoteProducts() {
+    public List<RemoteProductInfo> getRemoteProducts() {
         return remoteProducts;
     }
 
-    public void setRemoteProducts(List<Pair<String, RemoteProductManager>> remoteProducts) {
+    public void setRemoteProducts(List<RemoteProductInfo> remoteProducts) {
         this.remoteProducts = remoteProducts;
     }
 
-    public void addRemoteProduct(Pair<String, RemoteProductManager> remoteProduct) {
+    public void addRemoteProduct(RemoteProductInfo remoteProduct) {
         remoteProducts.add(remoteProduct);
     }
 
-    public void remoteRemoteProduct(Pair<String, RemoteProductManager> remoteProduct) {
+    public void removeRemoteProduct(RemoteProductInfo remoteProduct) {
         remoteProducts = remoteProducts.stream()
             .filter(rp -> {
-                return !rp.getLeft().equals(remoteProduct.getLeft()) && !rp.getRight().equals(remoteProduct.getRight());
+                return !rp.getScopeId().equals(remoteProduct.getScopeId()) && !rp.getRemoteProductManager().equals(remoteProduct.getRemoteProductManager());
             }).collect(Collectors.toList());
     }
-
-    // public String getScopeId() {
-    //     return scopeId;
-    // }
-
-    // public void setScopeId(String scopeId) {
-    //     this.scopeId = scopeId;
-    // }
-
-    // public RemoteProductManager getRemoteProductManager() {
-    //     return remoteProductManager;
-    // }
-
-    // public void setRemoteProductManager(RemoteProductManager remoteProductManager) {
-    //     this.remoteProductManager = remoteProductManager;
-    // }
-
 }

--- a/src/main/java/edu/tamu/app/model/RemoteProductInfo.java
+++ b/src/main/java/edu/tamu/app/model/RemoteProductInfo.java
@@ -1,0 +1,47 @@
+package edu.tamu.app.model;
+
+import static javax.persistence.CascadeType.DETACH;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.REFRESH;
+import static javax.persistence.FetchType.EAGER;
+
+import javax.persistence.Embeddable;
+import javax.persistence.ManyToOne;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+import edu.tamu.weaver.response.ApiView;
+
+@Embeddable
+public class RemoteProductInfo {
+
+    @JsonView(ApiView.Partial.class)
+    private String scopeId;
+
+    @JsonView(ApiView.Partial.class)
+    @ManyToOne(targetEntity = RemoteProductManager.class, fetch = EAGER, cascade = { DETACH, REFRESH, MERGE }, optional = true)
+    private RemoteProductManager remoteProductManager;
+
+    public RemoteProductInfo() {}
+
+    public RemoteProductInfo(String scopeId, RemoteProductManager remoteProductManager) {
+        this.scopeId = scopeId;
+        this.remoteProductManager = remoteProductManager;
+    }
+
+    public String getScopeId() {
+        return scopeId;
+    }
+
+    public void setScopeId(String scopeId) {
+        this.scopeId = scopeId;
+    }
+
+    public RemoteProductManager getRemoteProductManager() {
+        return remoteProductManager;
+    }
+
+    public void setRemoteProductManager(RemoteProductManager remoteProductManager) {
+        this.remoteProductManager = remoteProductManager;
+    }
+}

--- a/src/main/java/edu/tamu/app/model/repo/InternalRequestRepo.java
+++ b/src/main/java/edu/tamu/app/model/repo/InternalRequestRepo.java
@@ -1,0 +1,9 @@
+package edu.tamu.app.model.repo;
+
+import edu.tamu.app.model.InternalRequest;
+import edu.tamu.app.model.repo.custom.InternalRequestRepoCustom;
+import edu.tamu.weaver.data.model.repo.WeaverRepo;
+
+public interface InternalRequestRepo extends WeaverRepo<InternalRequest>, InternalRequestRepoCustom {
+
+}

--- a/src/main/java/edu/tamu/app/model/repo/custom/InternalRequestRepoCustom.java
+++ b/src/main/java/edu/tamu/app/model/repo/custom/InternalRequestRepoCustom.java
@@ -1,0 +1,5 @@
+package edu.tamu.app.model.repo.custom;
+
+public interface InternalRequestRepoCustom {
+
+}

--- a/src/main/java/edu/tamu/app/model/repo/impl/InternalRequestRepoImpl.java
+++ b/src/main/java/edu/tamu/app/model/repo/impl/InternalRequestRepoImpl.java
@@ -1,0 +1,15 @@
+package edu.tamu.app.model.repo.impl;
+
+import edu.tamu.app.model.InternalRequest;
+import edu.tamu.app.model.repo.InternalRequestRepo;
+import edu.tamu.app.model.repo.custom.InternalRequestRepoCustom;
+import edu.tamu.weaver.data.model.repo.impl.AbstractWeaverRepoImpl;
+
+public class InternalRequestRepoImpl extends AbstractWeaverRepoImpl<InternalRequest, InternalRequestRepo> implements InternalRequestRepoCustom {
+
+    @Override
+    protected String getChannel() {
+        return "/channel/internal/request";
+    }
+
+}

--- a/src/main/java/edu/tamu/app/model/validation/InternalRequestValidator.java
+++ b/src/main/java/edu/tamu/app/model/validation/InternalRequestValidator.java
@@ -1,0 +1,16 @@
+package edu.tamu.app.model.validation;
+
+import edu.tamu.weaver.validation.model.InputValidationType;
+import edu.tamu.weaver.validation.validators.BaseModelValidator;
+import edu.tamu.weaver.validation.validators.InputValidator;
+
+public class InternalRequestValidator extends BaseModelValidator {
+
+    public InternalRequestValidator() {
+        String titleProperty = "title";
+        this.addInputValidator(new InputValidator(InputValidationType.required, "An Internal Request requires a title", titleProperty, true));
+
+        String descriptionProperty = "description";
+        this.addInputValidator(new InputValidator(InputValidationType.required, "An Internal Request requires a description", descriptionProperty, true));
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,8 +14,14 @@ security.basic.enabled: false
 
 ---
 spring:
+  profiles: production, development, test
   profiles.active: production
 
+  h2:
+    console:
+      enabled: true
+      path: /admin/h2console
+      
   datasource:
     platform: h2
     driverClassName: org.h2.Driver
@@ -79,12 +85,12 @@ app:
   # Framework app properties #
   ############################
   # edu.tamu.weaver.auth.service.UserCredentialsService
-  authority.admins: 402001311,613001223,102001721,222004429,709005486,523008230,724001395,123456789,512004707
+  authority.admins: 402001311,613001223,102001721,222004429,709005486,523008230,724001395,123456789,512004707,427008012
   security:
     # edu.tamu.weaver.auth.service.CryptoService
     secret: verysecretsecret
     # edu.tamu.weaver.filter.CorsFilter
-    allow-access: http://localhost,http://localhost:8080,http://machuff.tamu.edu,http://janus.evans.tamu.edu,http://savell.evans.tamu.edu,http://jmicah.tamu.edu
+    allow-access: http://localhost,http://localhost:8080,http://localhost:8181,http://machuff.tamu.edu,http://janus.evans.tamu.edu,http://savell.evans.tamu.edu,http://jmicah.tamu.edu
   # edu.tamu.weaver.email.config.WeaverEmailConfig
   email:
     host: relay.tamu.edu
@@ -107,7 +113,7 @@ auth:
     jwt:
       secret: verysecretsecret
       issuer: localhost
-      duration: 1
+      duration: 100000000
   # edu.tamu.weaver.token.provider.controller.TokenController
   path: /auth
 
@@ -131,4 +137,4 @@ management:
     enabled-by-default: false
     health:
       enabled: true
----
+

--- a/src/test/java/edu/tamu/app/controller/InternalRequestControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/InternalRequestControllerTest.java
@@ -1,0 +1,233 @@
+package edu.tamu.app.controller;
+
+import static edu.tamu.weaver.response.ApiStatus.ERROR;
+import static edu.tamu.weaver.response.ApiStatus.SUCCESS;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import edu.tamu.app.cache.service.RemoteProductsScheduledCacheService;
+import edu.tamu.app.model.InternalRequest;
+import edu.tamu.app.model.Product;
+import edu.tamu.app.model.RemoteProductManager;
+import edu.tamu.app.model.ServiceType;
+import edu.tamu.app.model.repo.InternalRequestRepo;
+import edu.tamu.app.model.repo.ProductRepo;
+import edu.tamu.app.model.repo.RemoteProductManagerRepo;
+import edu.tamu.app.model.request.FeatureRequest;
+import edu.tamu.app.service.manager.RemoteProductManagerBean;
+import edu.tamu.app.service.registry.ManagementBeanRegistry;
+import edu.tamu.weaver.response.ApiResponse;
+
+@RunWith(SpringRunner.class)
+public class InternalRequestControllerTest {
+
+    private static final String TEST_REQUEST_TITLE_BELLS = "Test Feature Request Title Bells";
+    private static final String TEST_REQUEST_TITLE_WHISTLES = "Test Feature Request Title Whistles";
+    private static final String TEST_REQUEST_DESCRIPTION_BELLS = "Test Feature Request Description Bells";
+    private static final String TEST_REQUEST_DESCRIPTION_WHISTLES = "Test Feature Request Description Whistles";
+
+    private static final String TEST_PRODUCT1_NAME = "Test Product 1 Name";
+    private static final String TEST_PRODUCT1_SCOPE = "0001";
+    private static final String TEST_PRODUCT2_NAME = "Test Product 2 Name";
+    private static final String TEST_PRODUCT2_SCOPE = "0002";
+    private static final String TEST_PRODUCT_WITHOUT_RPM_NAME = "Test Product Without Remote Product Manager Name";
+
+    private static final String PUSH_ERROR_MESSAGE = "Error pushing request to Test Remote Product Manager for product Test Product 1 Name!";
+    private static final String NO_RPM_ERROR_MESSAGE = "Test Product Without Remote Product Manager Name product does not have a Remote Product Manager!";
+    private static final String NO_PRODUCT_ERROR_MESSAGE = "Product with id null not found!";
+
+    private static final RemoteProductManager TEST_PRODUCT1_REMOTE_PRODUCT_MANAGER = new RemoteProductManager("Test Remote Product Manager", ServiceType.VERSION_ONE, new HashMap<String, String>());
+
+    private static Product TEST_PRODUCT1 = new Product(TEST_PRODUCT1_NAME, TEST_PRODUCT1_SCOPE, TEST_PRODUCT1_REMOTE_PRODUCT_MANAGER);
+    private static Product TEST_PRODUCT2 = new Product(TEST_PRODUCT2_NAME);
+    private static Product TEST_PRODUCT_WIHTOUT_RPM = new Product(TEST_PRODUCT_WITHOUT_RPM_NAME);
+
+    private static FeatureRequest TEST_FEATURE_REQUEST = new FeatureRequest(TEST_REQUEST_TITLE_BELLS, TEST_REQUEST_DESCRIPTION_BELLS, TEST_PRODUCT1.getId(), TEST_PRODUCT1_SCOPE);
+
+    // NOTE: this is not really an invalid feature request
+    private static FeatureRequest TEST_INVALID_FEATURE_REQUEST = new FeatureRequest(TEST_REQUEST_TITLE_BELLS, TEST_REQUEST_DESCRIPTION_BELLS, TEST_PRODUCT1.getId(), TEST_PRODUCT1_SCOPE);
+    private static FeatureRequest TEST_FEATURE_REQUEST_WIHTOUT_VMS = new FeatureRequest(TEST_REQUEST_TITLE_BELLS, TEST_REQUEST_DESCRIPTION_BELLS, TEST_PRODUCT_WIHTOUT_RPM.getId(), TEST_PRODUCT2_SCOPE);
+    private static FeatureRequest TEST_FEATURE_REQUEST_WITHOUT_PRODUCT = new FeatureRequest();
+
+    private static Date TEST_REQUEST_CREATED_ON_BELLS = Date.from(Instant.now().minusSeconds(30L));
+    private static Date TEST_REQUEST_CREATED_ON_WHISTLES = Date.from(Instant.now());
+
+    private static InternalRequest TEST_REQUEST_BELLS = new InternalRequest(TEST_REQUEST_TITLE_BELLS, TEST_REQUEST_DESCRIPTION_BELLS, TEST_REQUEST_CREATED_ON_BELLS);
+    private static InternalRequest TEST_REQUEST_WHISTLES = new InternalRequest(TEST_REQUEST_TITLE_WHISTLES, TEST_REQUEST_DESCRIPTION_WHISTLES, TEST_REQUEST_CREATED_ON_WHISTLES);
+
+    private static List<Product> mockProductList = new ArrayList<Product>(Arrays.asList(new Product[] { TEST_PRODUCT1, TEST_PRODUCT2 }));
+
+    private static List<InternalRequest> mockRequestsRepo;
+
+    private ApiResponse apiResponse;
+
+    @Mock
+    private InternalRequestRepo internalRequestRepo;
+
+    @Mock
+    private ProductRepo productRepo;
+
+    @Mock
+    private RemoteProductManagerRepo remoteProductManagerRepo;
+
+    @Mock
+    private ManagementBeanRegistry managementBeanRegistry;
+
+    @Mock
+    private RemoteProductManagerBean remoteProductManagementBean;
+
+    @Mock
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    @Mock
+    private RemoteProductsScheduledCacheService remoteProductsScheduledCacheService;
+
+    @InjectMocks
+    private InternalRequestController internalRequestController;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        TEST_PRODUCT1.setId(1L);
+        TEST_PRODUCT2.setId(2L);
+
+        TEST_REQUEST_BELLS.setId(1L);
+        TEST_REQUEST_WHISTLES.setId(2L);
+
+        mockRequestsRepo = new ArrayList<InternalRequest>(Arrays.asList(new InternalRequest[] { TEST_REQUEST_BELLS, TEST_REQUEST_WHISTLES }));
+
+        when(internalRequestRepo.findAll()).thenReturn(mockRequestsRepo);
+        when(internalRequestRepo.count()).thenReturn((long) mockRequestsRepo.size());
+        when(internalRequestRepo.create(any(InternalRequest.class))).thenReturn(TEST_REQUEST_BELLS);
+        when(internalRequestRepo.update(any(InternalRequest.class))).thenReturn(TEST_REQUEST_BELLS);
+        when(internalRequestRepo.findOne(any(Long.class))).thenReturn(TEST_REQUEST_BELLS);
+        when(managementBeanRegistry.getService(any(String.class))).thenReturn(remoteProductManagementBean);
+
+        doAnswer(new Answer<ApiResponse>() {
+            @Override
+            public ApiResponse answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                InternalRequest request = (InternalRequest) args[0];
+
+                for (int i = 0; i < mockRequestsRepo.size(); i++) {
+                    InternalRequest r = mockRequestsRepo.get(i);
+                    if (r.getId() == request.getId()) {
+                        mockRequestsRepo.remove(i);
+                        return new ApiResponse(SUCCESS);
+                    }
+                }
+
+                return new ApiResponse(ERROR);
+            }
+        }).when(internalRequestRepo).delete(any(InternalRequest.class));
+
+        when(productRepo.findAll()).thenReturn(mockProductList);
+
+        when(remoteProductManagerRepo.findOne(any(Long.class))).thenReturn(TEST_PRODUCT1_REMOTE_PRODUCT_MANAGER);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRead() {
+        ApiResponse apiResponse = internalRequestController.read();
+
+        assertEquals("Request for Internal Request was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
+        assertEquals("Number of Internal Requests was not correct", 2, ((ArrayList<InternalRequest>) apiResponse.getPayload().get("ArrayList<InternalRequest>")).size());
+    }
+
+    @Test
+    public void testReadById() {
+        ApiResponse apiResponse = internalRequestController.read(TEST_REQUEST_BELLS.getId());
+
+        assertEquals("Request for Internal Request was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
+        assertEquals("Internal Request read was incorrect", TEST_REQUEST_BELLS.getTitle(), ((InternalRequest) apiResponse.getPayload().get("InternalRequest")).getTitle());
+    }
+
+    @Test
+    public void testCreate() {
+        ApiResponse apiResponse = internalRequestController.create(TEST_REQUEST_BELLS);
+
+        assertEquals("Internal Request was not successfully created", SUCCESS, apiResponse.getMeta().getStatus());
+    }
+
+    @Test
+    public void testUpdate() {
+        ApiResponse apiResponse = internalRequestController.update(TEST_REQUEST_BELLS);
+
+        assertEquals("Internal Request was not successfully updated", SUCCESS, apiResponse.getMeta().getStatus());
+    }
+
+    @Test
+    public void testDelete() {
+        ApiResponse apiResponse = internalRequestController.delete(TEST_REQUEST_WHISTLES);
+
+        assertEquals("Internal Request was not successfully deleted", SUCCESS, apiResponse.getMeta().getStatus());
+    }
+
+    @Test
+    public void testPush() throws Exception {
+        int initialCount = mockRequestsRepo.size();
+
+        when(remoteProductManagementBean.push(any(FeatureRequest.class))).thenReturn(TEST_FEATURE_REQUEST);
+        when(managementBeanRegistry.getService(any(String.class))).thenReturn(remoteProductManagementBean);
+        when(productRepo.findOne(any(Long.class))).thenReturn(TEST_PRODUCT1);
+
+        apiResponse = internalRequestController.push(TEST_REQUEST_BELLS.getId(), TEST_FEATURE_REQUEST);
+
+        assertEquals("Product controller did not push request", SUCCESS, apiResponse.getMeta().getStatus());
+        assertEquals("InternalRequest should be deleted after successful push", initialCount - 1, mockRequestsRepo.size());
+    }
+
+    @Test
+    public void testPushToInvalidRemoteProductManager() {
+        when(productRepo.findOne(any(Long.class))).thenReturn(TEST_PRODUCT1);
+
+        apiResponse = internalRequestController.push(TEST_REQUEST_BELLS.getId(), TEST_INVALID_FEATURE_REQUEST);
+
+        assertEquals("Invalid push did not throw an exception", ERROR, apiResponse.getMeta().getStatus());
+        assertEquals("Push without Remote Product Manager did not result in the expected error", PUSH_ERROR_MESSAGE, apiResponse.getMeta().getMessage());
+        assertEquals("InternalRequest should not be deleted after failed push", 2, internalRequestRepo.count());
+    }
+
+    @Test
+    public void testPushWithoutRemoteProductManager() {
+        when(productRepo.findOne(any(Long.class))).thenReturn(TEST_PRODUCT_WIHTOUT_RPM);
+
+        apiResponse = internalRequestController.push(TEST_REQUEST_BELLS.getId(), TEST_FEATURE_REQUEST_WIHTOUT_VMS);
+
+        assertEquals("Push without Remote Product Manager did not result in an error", ERROR, apiResponse.getMeta().getStatus());
+        assertEquals("Push without Remote Product Manager did not result in the expected error", NO_RPM_ERROR_MESSAGE, apiResponse.getMeta().getMessage());
+        assertEquals("InternalRequest should not be deleted after failed push", 2, internalRequestRepo.count());
+    }
+
+    @Test
+    public void testPushWithoutProduct() {
+        apiResponse = internalRequestController.push(TEST_REQUEST_BELLS.getId(), TEST_FEATURE_REQUEST_WITHOUT_PRODUCT);
+
+        assertEquals("Push without Product did not result in an error", ERROR, apiResponse.getMeta().getStatus());
+        assertEquals("Push without Product did not result in the expected error", NO_PRODUCT_ERROR_MESSAGE, apiResponse.getMeta().getMessage());
+        assertEquals("InternalRequest should not be deleted after failed push", 2, internalRequestRepo.count());
+    }
+
+}

--- a/src/test/java/edu/tamu/app/controller/StatusControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/StatusControllerTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -19,11 +18,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-
 import edu.tamu.app.model.Status;
-import edu.tamu.app.model.User;
 import edu.tamu.app.model.repo.StatusRepo;
 import edu.tamu.weaver.response.ApiResponse;
 
@@ -41,7 +36,7 @@ public class StatusControllerTest {
     private StatusController statusController;
 
     @Before
-    public void setup() throws JsonParseException, JsonMappingException, IOException {
+    public void setup() {
         MockitoAnnotations.initMocks(this);
         noneStatus = new Status("None", new HashSet<String>(Arrays.asList(new String[] { "None", "Future" })));
         doneStatus = new Status("Done", new HashSet<String>(Arrays.asList(new String[] { "Done" })));
@@ -59,20 +54,20 @@ public class StatusControllerTest {
     public void testRead() {
         ApiResponse apiResponse = statusController.read();
         assertEquals("Request for statuses was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
-        assertEquals("Number of statuses was not correct", 2, ((ArrayList<User>) apiResponse.getPayload().get("ArrayList<Status>")).size());
+        assertEquals("Number of statuses was not correct", 2, ((ArrayList<Status>) apiResponse.getPayload().get("ArrayList<Status>")).size());
     }
 
     @Test
     public void testReadById() {
-        ApiResponse apiResponse = statusController.read(1L);
-        assertEquals("Request for statuse was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
-        assertEquals("Statue read was incorrect", "None", ((Status) apiResponse.getPayload().get("Status")).getIdentifier());
+        ApiResponse apiResponse = statusController.read(noneStatus.getId());
+        assertEquals("Request for status was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
+        assertEquals("Status read was incorrect", "None", ((Status) apiResponse.getPayload().get("Status")).getIdentifier());
     }
 
     @Test
     public void testCreate() {
         ApiResponse apiResponse = statusController.create(noneStatus);
-        assertEquals("Status was not successfully updated", SUCCESS, apiResponse.getMeta().getStatus());
+        assertEquals("Status was not successfully created", SUCCESS, apiResponse.getMeta().getStatus());
     }
 
     @Test


### PR DESCRIPTION
Resolves #62 

Maintain existing end-point for submitting FeatureRequest, unchanged.
The FeatureRequest is then converted into an InternalRequest and stored in the database.
The product end-point no longer performs push and instead new end-points are created under `/internal/request/` to perform the push.
This new end-point `/internal/request/` includes CRUD operations.

The new push end-point `/internal/request/push` will convert the InternalRequest to a FeatureRequest before pushing.
This ensures that any service outside of Product Management System will only know about FeatureRequest and do not need to be aware of InternalRequest in any manner.
From the point of view of services outside of Product Management System, Product Management System receives a FeatureRequest and pushes a FeatureRequest.