### PR TITLE
Follow up on changes to internal cards, stats

### DIFF
--- a/src/main/java/edu/tamu/app/cache/model/ProductStats.java
+++ b/src/main/java/edu/tamu/app/cache/model/ProductStats.java
@@ -18,6 +18,8 @@ public class ProductStats implements Serializable {
 
     private final long defectCount;
 
+    private final long internalCount;
+
     public ProductStats() {
         super();
         id = "";
@@ -26,9 +28,10 @@ public class ProductStats implements Serializable {
         issueCount = 0;
         featureCount = 0;
         defectCount = 0;
+        internalCount = 0;
     }
 
-    public ProductStats(String id, String name, long requestCount, long issueCount, long featureCount, long defectCount) {
+    public ProductStats(String id, String name, long requestCount, long issueCount, long featureCount, long defectCount, long internalCount) {
         super();
         this.id = id;
         this.name = name;
@@ -36,6 +39,7 @@ public class ProductStats implements Serializable {
         this.issueCount = issueCount;
         this.featureCount = featureCount;
         this.defectCount = defectCount;
+        this.internalCount = internalCount;
     }
 
     public String getId() {
@@ -60,6 +64,10 @@ public class ProductStats implements Serializable {
 
     public long getDefectCount() {
         return defectCount;
+    }
+
+    public long getInternalCount() {
+        return internalCount;
     }
 
     public long getBacklogItemCount() {

--- a/src/main/java/edu/tamu/app/cache/model/RemoteProduct.java
+++ b/src/main/java/edu/tamu/app/cache/model/RemoteProduct.java
@@ -8,8 +8,8 @@ public class RemoteProduct extends ProductStats {
         super();
     }
 
-    public RemoteProduct(String id, String name, long requestCount, long issueCount, long featureCount, long defectCount) {
-        super(id, name, requestCount, issueCount, featureCount, defectCount);
+    public RemoteProduct(String id, String name, long requestCount, long issueCount, long featureCount, long defectCount, long internalCount) {
+        super(id, name, requestCount, issueCount, featureCount, defectCount, internalCount);
     }
 
 }

--- a/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
@@ -18,6 +18,7 @@ import edu.tamu.app.cache.model.RemoteProduct;
 import edu.tamu.app.model.Product;
 import edu.tamu.app.model.RemoteProductInfo;
 import edu.tamu.app.model.RemoteProductManager;
+import edu.tamu.app.model.repo.InternalRequestRepo;
 import edu.tamu.app.model.repo.ProductRepo;
 import edu.tamu.weaver.response.ApiResponse;
 
@@ -28,6 +29,9 @@ public class ProductsStatsScheduledCacheService extends AbstractProductScheduled
 
     @Autowired
     private ProductRepo productRepo;
+
+    @Autowired
+    private InternalRequestRepo internalRequestRepo;
 
     @Autowired
     private RemoteProductsScheduledCacheService remoteProductsScheduledCacheService;
@@ -82,10 +86,11 @@ public class ProductsStatsScheduledCacheService extends AbstractProductScheduled
     private ProductStats getProductStats(Product product) {
         String id = product.getId().toString();
         String name = product.getName();
-        int requestCount = 0;
-        int issueCount = 0;
-        int featureCount = 0;
-        int defectCount = 0;
+        long requestCount = 0;
+        long issueCount = 0;
+        long featureCount = 0;
+        long defectCount = 0;
+        long internalCount = internalRequestRepo.countByProductId(product.getId());
 
         List<RemoteProductInfo> remoteProductInfo = product.getRemoteProductInfo();
         for (RemoteProductInfo rpi : remoteProductInfo) {
@@ -102,7 +107,7 @@ public class ProductsStatsScheduledCacheService extends AbstractProductScheduled
             }
         }
 
-        return new ProductStats(id, name, requestCount, issueCount, featureCount, defectCount);
+        return new ProductStats(id, name, requestCount, issueCount, featureCount, defectCount, internalCount);
     }
 
     @Override

--- a/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheService.java
@@ -90,7 +90,12 @@ public class ProductsStatsScheduledCacheService extends AbstractProductScheduled
         long issueCount = 0;
         long featureCount = 0;
         long defectCount = 0;
-        long internalCount = internalRequestRepo.countByProductId(product.getId());
+        long internalCount = 0;
+
+        Optional<Long> productId = Optional.ofNullable(product.getId());
+        if (productId.isPresent()) {
+            internalCount = internalRequestRepo.countByProductId(productId.get());
+        }
 
         List<RemoteProductInfo> remoteProductInfo = product.getRemoteProductInfo();
         for (RemoteProductInfo rpi : remoteProductInfo) {

--- a/src/main/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheService.java
+++ b/src/main/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheService.java
@@ -43,16 +43,22 @@ public class RemoteProductsScheduledCacheService extends AbstractScheduledCacheS
 
     public void update() {
         logger.info("Caching remote products...");
+
         Map<Long, List<RemoteProduct>> remoteProducts = new HashMap<Long, List<RemoteProduct>>();
-        for (RemoteProductManager remoteProductManager : remoteProductManagerRepo.findAll()) {
-            RemoteProductManagerBean remoteProductManagerBean = (RemoteProductManagerBean) managementBeanRegistry
-                    .getService(remoteProductManager.getName());
-            try {
-                remoteProducts.put(remoteProductManager.getId(), remoteProductManagerBean.getRemoteProduct());
-            } catch (Exception e) {
-                e.printStackTrace();
+        Optional<List<RemoteProductManager>> remoteProductManagers = Optional.ofNullable(remoteProductManagerRepo.findAll());
+
+        if (remoteProductManagers.isPresent()){
+            for (RemoteProductManager remoteProductManager : remoteProductManagers.get()) {
+                RemoteProductManagerBean remoteProductManagerBean = (RemoteProductManagerBean) managementBeanRegistry
+                        .getService(remoteProductManager.getName());
+                try {
+                    remoteProducts.put(remoteProductManager.getId(), remoteProductManagerBean.getRemoteProduct());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
+
         set(remoteProducts);
         logger.info("Finished caching remote products");
     }

--- a/src/main/java/edu/tamu/app/controller/InternalRequestController.java
+++ b/src/main/java/edu/tamu/app/controller/InternalRequestController.java
@@ -121,7 +121,7 @@ public class InternalRequestController {
     @PreAuthorize("hasRole('ANONYMOUS')")
     @GetMapping("/stats")
     public ApiResponse stats() {
-        return new ApiResponse(SUCCESS, new InternalStats(internalRequestRepo.count()));
+        return new ApiResponse(SUCCESS, new InternalStats(internalRequestRepo.countByProductIsNull(), internalRequestRepo.count()));
     }
 
 }

--- a/src/main/java/edu/tamu/app/controller/ProductController.java
+++ b/src/main/java/edu/tamu/app/controller/ProductController.java
@@ -6,6 +6,7 @@ import static edu.tamu.weaver.validation.model.BusinessValidationType.CREATE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.DELETE;
 import static edu.tamu.weaver.validation.model.BusinessValidationType.UPDATE;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -131,8 +132,17 @@ public class ProductController {
     @PostMapping("/feature")
     @PreAuthorize("hasRole('MANAGER') or @whitelist.isAllowed()")
     public ApiResponse pushRequest(@RequestBody FeatureRequest request) {
-        internalRequestRepo.create(new InternalRequest(request.getTitle(), request.getDescription()));
-        return new ApiResponse(SUCCESS, request);
+        Optional<Product> product = Optional.ofNullable(productRepo.findOne(request.getProductId()));
+        ApiResponse response;
+
+        if (product.isPresent()) {
+            internalRequestRepo.create(new InternalRequest(request.getTitle(), request.getDescription(), product.get(), new Date()));
+            response = new ApiResponse(SUCCESS, request);
+        } else {
+            response = new ApiResponse(ERROR, "Product with id " + request.getProductId() + " not found!");
+        }
+
+        return response;
     }
 
     @GetMapping("/remote-products/{productId}")

--- a/src/main/java/edu/tamu/app/model/InternalRequest.java
+++ b/src/main/java/edu/tamu/app/model/InternalRequest.java
@@ -1,9 +1,15 @@
 package edu.tamu.app.model;
 
+import static javax.persistence.CascadeType.DETACH;
+import static javax.persistence.CascadeType.MERGE;
+import static javax.persistence.CascadeType.REFRESH;
+import static javax.persistence.FetchType.EAGER;
+
 import java.util.Date;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -27,6 +33,10 @@ public class InternalRequest extends ValidatingBaseEntity {
     @JsonView(ApiView.Partial.class)
     private String description;
 
+    @JsonView(ApiView.Partial.class)
+    @ManyToOne(targetEntity = Product.class, fetch = EAGER, cascade = { DETACH, REFRESH, MERGE }, optional = true)
+    private Product product;
+
     @NotNull
     @Column(nullable = false, updatable = false)
     @CreationTimestamp
@@ -37,15 +47,10 @@ public class InternalRequest extends ValidatingBaseEntity {
         this.modelValidator = new InternalRequestValidator();
     }
 
-    public InternalRequest(String title, String description) {
+    public InternalRequest(String title, String description, Product product, Date createdOn) {
         this.title = title;
         this.description = description;
-        this.createdOn = new Date();
-    }
-
-    public InternalRequest(String title, String description, Date createdOn) {
-        this.title = title;
-        this.description = description;
+        this.product = product;
         this.createdOn = createdOn;
     }
 
@@ -63,6 +68,14 @@ public class InternalRequest extends ValidatingBaseEntity {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
     }
 
     public Date getCreatedOn() {

--- a/src/main/java/edu/tamu/app/model/InternalStats.java
+++ b/src/main/java/edu/tamu/app/model/InternalStats.java
@@ -6,20 +6,31 @@ public class InternalStats implements Serializable {
 
     private static final long serialVersionUID = -1622544796949909087L;
 
-    private final long internalCount;
+    private final long unassignedCount;
+    private final long totalCount;
 
     public InternalStats() {
         super();
-        internalCount = 0;
+        unassignedCount = 0;
+        totalCount = 0;
     }
 
-    public InternalStats(long internalCount) {
+    public InternalStats(long unassignedCount, long totalCount) {
         super();
-        this.internalCount = internalCount;
+        this.unassignedCount = unassignedCount;
+        this.totalCount = totalCount;
     }
 
-    public long getInternalCount() {
-        return internalCount;
+    public long getAssignedCount() {
+        return totalCount - unassignedCount;
+    }
+
+    public long getUnassignedCount() {
+        return unassignedCount;
+    }
+
+    public long getTotalCount() {
+        return totalCount;
     }
 
 }

--- a/src/main/java/edu/tamu/app/model/repo/InternalRequestRepo.java
+++ b/src/main/java/edu/tamu/app/model/repo/InternalRequestRepo.java
@@ -6,4 +6,8 @@ import edu.tamu.weaver.data.model.repo.WeaverRepo;
 
 public interface InternalRequestRepo extends WeaverRepo<InternalRequest>, InternalRequestRepoCustom {
 
+    public Long countByProductId(Long productId);
+
+    public Long countByProductIsNull();
+
 }

--- a/src/main/java/edu/tamu/app/service/manager/GitHubService.java
+++ b/src/main/java/edu/tamu/app/service/manager/GitHubService.java
@@ -19,13 +19,13 @@ import org.kohsuke.github.GHIssueState;
 import org.kohsuke.github.GHLabel;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHProject;
+import org.kohsuke.github.GHProject.ProjectStateFilter;
 import org.kohsuke.github.GHProjectCard;
 import org.kohsuke.github.GHProjectColumn;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 import org.kohsuke.github.GitHubBuilder;
-import org.kohsuke.github.GHProject.ProjectStateFilter;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -176,7 +176,7 @@ public class GitHubService extends MappingRemoteProductManagerBean {
         long featureCount = getPrimaryWorkItemCount(FEATURE_LABEL, repo, labels);
         long defectCount = getPrimaryWorkItemCount(DEFECT_LABEL, repo, labels);
 
-        return new RemoteProduct(scopeId, name, requestCount, issueCount, featureCount, defectCount);
+        return new RemoteProduct(scopeId, name, requestCount, issueCount, featureCount, defectCount, 0L);
     }
 
     private long getPrimaryWorkItemCount(final String type, final GHRepository repo, final List<GHLabel> labels)

--- a/src/main/java/edu/tamu/app/service/manager/VersionOneService.java
+++ b/src/main/java/edu/tamu/app/service/manager/VersionOneService.java
@@ -80,11 +80,12 @@ public class VersionOneService extends MappingRemoteProductManagerBean {
         for (Asset product : result.getAssets()) {
             String scopeId = parseId(product.getOid());
             String name = product.getAttribute(nameAttributeDefinition).getValue().toString();
-            int requestCount = getPrimaryWorkItemCount("Request", scopeId);
-            int issueCount = getPrimaryWorkItemCount("Issue", scopeId);
-            int storyCount = getPrimaryWorkItemCount("Story", scopeId);
-            int defectCount = getPrimaryWorkItemCount("Defect", scopeId);
-            remoteProducts.add(new RemoteProduct(scopeId, name, requestCount, issueCount, storyCount, defectCount));
+            long requestCount = getPrimaryWorkItemCount("Request", scopeId);
+            long issueCount = getPrimaryWorkItemCount("Issue", scopeId);
+            long storyCount = getPrimaryWorkItemCount("Story", scopeId);
+            long defectCount = getPrimaryWorkItemCount("Defect", scopeId);
+            long internalCount = 0;
+            remoteProducts.add(new RemoteProduct(scopeId, name, requestCount, issueCount, storyCount, defectCount, internalCount));
         }
         return remoteProducts;
     }
@@ -100,11 +101,12 @@ public class VersionOneService extends MappingRemoteProductManagerBean {
         QueryResult result = services.retrieve(query);
         Asset product = result.getAssets()[0];
         String name = product.getAttribute(nameAttributeDefinition).getValue().toString();
-        int requestCount = getPrimaryWorkItemCount("Request", scopeId);
-        int issueCount = getPrimaryWorkItemCount("Issue", scopeId);
-        int storyCount = getPrimaryWorkItemCount("Story", scopeId);
-        int defectCount = getPrimaryWorkItemCount("Defect", scopeId);
-        return new RemoteProduct(scopeId, name, requestCount, issueCount, storyCount, defectCount);
+        long requestCount = getPrimaryWorkItemCount("Request", scopeId);
+        long issueCount = getPrimaryWorkItemCount("Issue", scopeId);
+        long storyCount = getPrimaryWorkItemCount("Story", scopeId);
+        long defectCount = getPrimaryWorkItemCount("Defect", scopeId);
+
+        return new RemoteProduct(scopeId, name, requestCount, issueCount, storyCount, defectCount, 0L);
     }
 
     public int getPrimaryWorkItemCount(final String type, final String scopeId) throws ConnectionException, APIException, OidException {

--- a/src/test/java/edu/tamu/app/cache/ProductStatsCacheTest.java
+++ b/src/test/java/edu/tamu/app/cache/ProductStatsCacheTest.java
@@ -54,7 +54,7 @@ public class ProductStatsCacheTest {
     }
 
     private ProductStats getMockProductStats() {
-        return new ProductStats("0001", "Sprint 1", 2, 3, 10, 3);
+        return new ProductStats("0001", "Sprint 1", 2, 3, 10, 3, 1);
     }
 
 }

--- a/src/test/java/edu/tamu/app/cache/ProductStatsCacheTest.java
+++ b/src/test/java/edu/tamu/app/cache/ProductStatsCacheTest.java
@@ -50,6 +50,7 @@ public class ProductStatsCacheTest {
         assertEquals("Cached product stats had incorrect number of issues!", 3, remoteProductsCache.get(0).getIssueCount());
         assertEquals("Cached product stats had incorrect number of features!", 10, remoteProductsCache.get(0).getFeatureCount());
         assertEquals("Cached product stats had incorrect number of defects!", 3, remoteProductsCache.get(0).getDefectCount());
+        assertEquals("Cached product stats had incorrect number of internals!", 1, remoteProductsCache.get(0).getInternalCount());
         assertEquals("Cached product stats had incorrect total backlog items!", 13, remoteProductsCache.get(0).getBacklogItemCount());
     }
 

--- a/src/test/java/edu/tamu/app/cache/RemoteProductsCacheTest.java
+++ b/src/test/java/edu/tamu/app/cache/RemoteProductsCacheTest.java
@@ -57,7 +57,7 @@ public class RemoteProductsCacheTest {
         assertEquals("Cached remote product had incorrect number of issues!", 3, remoteProductsCache.get(1L).get(0).getIssueCount());
         assertEquals("Cached remote product had incorrect number of features!", 10, remoteProductsCache.get(1L).get(0).getFeatureCount());
         assertEquals("Cached remote product had incorrect number of defects!", 3, remoteProductsCache.get(1L).get(0).getDefectCount());
-        assertEquals("Cached remote product had incorrect number of internals!", 1, remoteProductsCache.get(1L).get(0).getDefectCount());
+        assertEquals("Cached remote product had incorrect number of internals!", 1, remoteProductsCache.get(1L).get(0).getInternalCount());
         assertEquals("Cached remote product had incorrect total backlog items!", 13, remoteProductsCache.get(1L).get(0).getBacklogItemCount());
     }
 

--- a/src/test/java/edu/tamu/app/cache/RemoteProductsCacheTest.java
+++ b/src/test/java/edu/tamu/app/cache/RemoteProductsCacheTest.java
@@ -57,11 +57,12 @@ public class RemoteProductsCacheTest {
         assertEquals("Cached remote product had incorrect number of issues!", 3, remoteProductsCache.get(1L).get(0).getIssueCount());
         assertEquals("Cached remote product had incorrect number of features!", 10, remoteProductsCache.get(1L).get(0).getFeatureCount());
         assertEquals("Cached remote product had incorrect number of defects!", 3, remoteProductsCache.get(1L).get(0).getDefectCount());
+        assertEquals("Cached remote product had incorrect number of internals!", 1, remoteProductsCache.get(1L).get(0).getDefectCount());
         assertEquals("Cached remote product had incorrect total backlog items!", 13, remoteProductsCache.get(1L).get(0).getBacklogItemCount());
     }
 
     private RemoteProduct getMockRemoteProduct() {
-        return new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3);
+        return new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3, 1);
     }
 
 }

--- a/src/test/java/edu/tamu/app/cache/controller/ProductsStatsCacheControllerTest.java
+++ b/src/test/java/edu/tamu/app/cache/controller/ProductsStatsCacheControllerTest.java
@@ -67,6 +67,7 @@ public class ProductsStatsCacheControllerTest {
         assertEquals(3, productsStatsCache.get(0).getIssueCount());
         assertEquals(10, productsStatsCache.get(0).getFeatureCount());
         assertEquals(3, productsStatsCache.get(0).getDefectCount());
+        assertEquals(1, productsStatsCache.get(0).getInternalCount());
         assertEquals(13, productsStatsCache.get(0).getBacklogItemCount());
     }
 
@@ -77,7 +78,7 @@ public class ProductsStatsCacheControllerTest {
     }
 
     private ProductStats getMockProductStats() {
-        return new ProductStats("0001", "Sprint 1", 2, 3, 10, 3);
+        return new ProductStats("0001", "Sprint 1", 2, 3, 10, 3, 1);
     }
 
 }

--- a/src/test/java/edu/tamu/app/cache/controller/RemoteProductsCacheControllerTest.java
+++ b/src/test/java/edu/tamu/app/cache/controller/RemoteProductsCacheControllerTest.java
@@ -72,6 +72,7 @@ public class RemoteProductsCacheControllerTest {
         assertEquals(3, remoteProducts.get(0).getIssueCount());
         assertEquals(10, remoteProducts.get(0).getFeatureCount());
         assertEquals(3, remoteProducts.get(0).getDefectCount());
+        assertEquals(1, remoteProducts.get(0).getInternalCount());
         assertEquals(13, remoteProducts.get(0).getBacklogItemCount());
     }
 
@@ -84,7 +85,7 @@ public class RemoteProductsCacheControllerTest {
     }
 
     private RemoteProduct getMockRemoteProduct() {
-        return new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3);
+        return new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3, 1);
     }
 
 }

--- a/src/test/java/edu/tamu/app/cache/model/ProductStatsTest.java
+++ b/src/test/java/edu/tamu/app/cache/model/ProductStatsTest.java
@@ -11,13 +11,14 @@ public class ProductStatsTest {
 
     @Test
     public void testNewProductStats() {
-        ProductStats productStats = new ProductStats("0001", "Sprint 1", 2, 3, 10, 3);
+        ProductStats productStats = new ProductStats("0001", "Sprint 1", 2, 3, 10, 3, 1);
         assertEquals("0001", productStats.getId());
         assertEquals("Sprint 1", productStats.getName());
         assertEquals(2, productStats.getRequestCount());
         assertEquals(3, productStats.getIssueCount());
         assertEquals(10, productStats.getFeatureCount());
         assertEquals(3, productStats.getDefectCount());
+        assertEquals(1, productStats.getInternalCount());
         assertEquals(13, productStats.getBacklogItemCount());
     }
 

--- a/src/test/java/edu/tamu/app/cache/model/RemoteProductTest.java
+++ b/src/test/java/edu/tamu/app/cache/model/RemoteProductTest.java
@@ -11,13 +11,14 @@ public class RemoteProductTest {
 
     @Test
     public void testNewRemoteProduct() {
-        RemoteProduct remoteProduct = new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3);
+        RemoteProduct remoteProduct = new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3, 1);
         assertEquals("0001", remoteProduct.getId());
         assertEquals("Sprint 1", remoteProduct.getName());
         assertEquals(2, remoteProduct.getRequestCount());
         assertEquals(3, remoteProduct.getIssueCount());
         assertEquals(10, remoteProduct.getFeatureCount());
         assertEquals(3, remoteProduct.getDefectCount());
+        assertEquals(1, remoteProduct.getInternalCount());
         assertEquals(13, remoteProduct.getBacklogItemCount());
     }
 

--- a/src/test/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheServiceTest.java
+++ b/src/test/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheServiceTest.java
@@ -32,6 +32,7 @@ import edu.tamu.app.model.Product;
 import edu.tamu.app.model.RemoteProductInfo;
 import edu.tamu.app.model.RemoteProductManager;
 import edu.tamu.app.model.ServiceType;
+import edu.tamu.app.model.repo.InternalRequestRepo;
 import edu.tamu.app.model.repo.ProductRepo;
 
 @RunWith(SpringRunner.class)
@@ -50,6 +51,9 @@ public class ProductsStatsScheduledCacheServiceTest {
     private ProductRepo productRepo;
 
     @Mock
+    private InternalRequestRepo internalRequestRepo;
+
+    @Mock
     private RemoteProductsScheduledCacheService remoteProductsScheduledCacheService;
 
     @Mock
@@ -63,6 +67,7 @@ public class ProductsStatsScheduledCacheServiceTest {
         MockitoAnnotations.initMocks(this);
         when(productRepo.findAll()).thenReturn(Arrays.asList(new Product[] { getMockProduct() }));
         when(remoteProductsScheduledCacheService.getRemoteProduct(any(Long.class), any(String.class))).thenReturn(Optional.of(getMockRemoteProduct()));
+        when(internalRequestRepo.countByProductId(any(Long.class))).thenReturn(1L);
     }
 
     @Test

--- a/src/test/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheServiceTest.java
+++ b/src/test/java/edu/tamu/app/cache/service/ProductsStatsScheduledCacheServiceTest.java
@@ -125,11 +125,11 @@ public class ProductsStatsScheduledCacheServiceTest {
     }
 
     private ProductStats getMockProductStats() {
-        return new ProductStats("1000", TEST_PRODUCT_NAME, 2, 3, 10, 3);
+        return new ProductStats("1000", TEST_PRODUCT_NAME, 2, 3, 10, 3, 1);
     }
 
     private RemoteProduct getMockRemoteProduct() {
-        return new RemoteProduct("1000", TEST_PRODUCT_NAME, 2, 3, 10, 3);
+        return new RemoteProduct("1000", TEST_PRODUCT_NAME, 2, 3, 10, 3, 1);
     }
 
     private void assertProductsStats(List<ProductStats> productStatsCache) {
@@ -141,6 +141,7 @@ public class ProductsStatsScheduledCacheServiceTest {
         assertEquals(3, productStatsCache.get(0).getIssueCount());
         assertEquals(10, productStatsCache.get(0).getFeatureCount());
         assertEquals(3, productStatsCache.get(0).getDefectCount());
+        assertEquals(1, productStatsCache.get(0).getInternalCount());
         assertEquals(13, productStatsCache.get(0).getBacklogItemCount());
     }
 

--- a/src/test/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheServiceTest.java
+++ b/src/test/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheServiceTest.java
@@ -112,7 +112,7 @@ public class RemoteProductsScheduledCacheServiceTest {
     }
 
     private RemoteProduct getMockRemoteProduct() {
-        return new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3);
+        return new RemoteProduct("0001", "Sprint 1", 2, 3, 10, 3, 1);
     }
 
     private void assertRemoteProducts(Map<Long, List<RemoteProduct>> remoteProductsCache) {
@@ -131,6 +131,7 @@ public class RemoteProductsScheduledCacheServiceTest {
         assertEquals(3, remoteProduct.getIssueCount());
         assertEquals(10, remoteProduct.getFeatureCount());
         assertEquals(3, remoteProduct.getDefectCount());
+        assertEquals(1, remoteProduct.getInternalCount());
         assertEquals(13, remoteProduct.getBacklogItemCount());
     }
 

--- a/src/test/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheServiceTest.java
+++ b/src/test/java/edu/tamu/app/cache/service/RemoteProductsScheduledCacheServiceTest.java
@@ -31,6 +31,7 @@ import com.versionone.apiclient.exceptions.OidException;
 import edu.tamu.app.cache.model.RemoteProduct;
 import edu.tamu.app.model.RemoteProductManager;
 import edu.tamu.app.model.ServiceType;
+import edu.tamu.app.model.repo.InternalRequestRepo;
 import edu.tamu.app.model.repo.RemoteProductManagerRepo;
 import edu.tamu.app.service.manager.VersionOneService;
 import edu.tamu.app.service.registry.ManagementBeanRegistry;
@@ -40,6 +41,9 @@ public class RemoteProductsScheduledCacheServiceTest {
 
     @Mock
     private RemoteProductManagerRepo remoteProductManagerRepo;
+
+    @Mock
+    private InternalRequestRepo internalRequestRepo;
 
     @Mock
     private ManagementBeanRegistry managementBeanRegistry;
@@ -56,6 +60,7 @@ public class RemoteProductsScheduledCacheServiceTest {
         VersionOneService versionOneService = mock(VersionOneService.class);
         when(remoteProductManagerRepo.findAll()).thenReturn(Arrays.asList(new RemoteProductManager[] { getMockRemoteProductManager() }));
         when(managementBeanRegistry.getService(any(String.class))).thenReturn(versionOneService);
+        when(internalRequestRepo.countByProductId(any(Long.class))).thenReturn(1L);
         when(versionOneService.getRemoteProduct()).thenReturn(Arrays.asList(new RemoteProduct[] { getMockRemoteProduct() }));
     }
 

--- a/src/test/java/edu/tamu/app/controller/InternalRequestControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/InternalRequestControllerTest.java
@@ -46,6 +46,7 @@ public class InternalRequestControllerTest {
 
     private static final String TEST_REQUEST_TITLE_BELLS = "Test Feature Request Title Bells";
     private static final String TEST_REQUEST_TITLE_WHISTLES = "Test Feature Request Title Whistles";
+
     private static final String TEST_REQUEST_DESCRIPTION_BELLS = "Test Feature Request Description Bells";
     private static final String TEST_REQUEST_DESCRIPTION_WHISTLES = "Test Feature Request Description Whistles";
 
@@ -70,8 +71,8 @@ public class InternalRequestControllerTest {
     private static Date TEST_REQUEST_CREATED_ON_BELLS = Date.from(Instant.now().minusSeconds(30L));
     private static Date TEST_REQUEST_CREATED_ON_WHISTLES = Date.from(Instant.now());
 
-    private static InternalRequest TEST_REQUEST_BELLS = new InternalRequest(TEST_REQUEST_TITLE_BELLS, TEST_REQUEST_DESCRIPTION_BELLS, TEST_REQUEST_CREATED_ON_BELLS);
-    private static InternalRequest TEST_REQUEST_WHISTLES = new InternalRequest(TEST_REQUEST_TITLE_WHISTLES, TEST_REQUEST_DESCRIPTION_WHISTLES, TEST_REQUEST_CREATED_ON_WHISTLES);
+    private static InternalRequest TEST_REQUEST_BELLS = new InternalRequest(TEST_REQUEST_TITLE_BELLS, TEST_REQUEST_DESCRIPTION_BELLS, TEST_PRODUCT1, TEST_REQUEST_CREATED_ON_BELLS);
+    private static InternalRequest TEST_REQUEST_WHISTLES = new InternalRequest(TEST_REQUEST_TITLE_WHISTLES, TEST_REQUEST_DESCRIPTION_WHISTLES, null, TEST_REQUEST_CREATED_ON_WHISTLES);
 
     private static List<Product> mockProductList = new ArrayList<Product>(Arrays.asList(new Product[] { TEST_PRODUCT1, TEST_PRODUCT2 }));
 
@@ -116,7 +117,9 @@ public class InternalRequestControllerTest {
         mockRequestsRepo = new ArrayList<InternalRequest>(Arrays.asList(new InternalRequest[] { TEST_REQUEST_BELLS, TEST_REQUEST_WHISTLES }));
 
         when(internalRequestRepo.findAll()).thenReturn(mockRequestsRepo);
-        when(internalRequestRepo.count()).thenReturn((long) mockRequestsRepo.size());
+        when(internalRequestRepo.count()).thenReturn(2L);
+        when(internalRequestRepo.countByProductId(any(Long.class))).thenReturn(1L);
+        when(internalRequestRepo.countByProductIsNull()).thenReturn(1L);
         when(internalRequestRepo.create(any(InternalRequest.class))).thenReturn(TEST_REQUEST_BELLS);
         when(internalRequestRepo.update(any(InternalRequest.class))).thenReturn(TEST_REQUEST_BELLS);
         when(remoteProductManagementBean.push(any(FeatureRequest.class))).thenReturn(TEST_FEATURE_REQUEST);
@@ -275,10 +278,26 @@ public class InternalRequestControllerTest {
     }
 
     @Test
-    public void testStats() {
+    public void testStatsAssigned() {
+        ApiResponse apiResponse = internalRequestController.stats();
+
+        assertEquals("Request for assigned Internal Request stats was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
+        assertEquals("Number of assigned Internal Requests was not correct", 1L, ((InternalStats) apiResponse.getPayload().get("InternalStats")).getAssignedCount());
+    }
+
+    @Test
+    public void testStatsUnassigned() {
+        ApiResponse apiResponse = internalRequestController.stats();
+
+        assertEquals("Request for unassigned Internal Request stats was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
+        assertEquals("Number of unassigned Internal Requests was not correct", 1L, ((InternalStats) apiResponse.getPayload().get("InternalStats")).getUnassignedCount());
+    }
+
+    @Test
+    public void testStatsTotal() {
         ApiResponse apiResponse = internalRequestController.stats();
 
         assertEquals("Request for Internal Request stats was unsuccessful", SUCCESS, apiResponse.getMeta().getStatus());
-        assertEquals("Number of Internal Requests was not correct", 2L, ((InternalStats) apiResponse.getPayload().get("InternalStats")).getInternalCount());
+        assertEquals("Number of Internal Requests was not correct", 2L, ((InternalStats) apiResponse.getPayload().get("InternalStats")).getTotalCount());
     }
 }

--- a/src/test/java/edu/tamu/app/controller/ProductControllerUnitTest.java
+++ b/src/test/java/edu/tamu/app/controller/ProductControllerUnitTest.java
@@ -8,8 +8,10 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
@@ -54,8 +56,6 @@ public class ProductControllerUnitTest {
     private static final String TEST_FEATURE_REQUEST_TITLE = "Test Feature Request Title";
     private static final String TEST_FEATURE_REQUEST_DESCRIPTION = "Test Feature Request Description";
 
-    private static final InternalRequest TEST_REQUEST_NAME = new InternalRequest(TEST_FEATURE_REQUEST_TITLE, TEST_FEATURE_REQUEST_DESCRIPTION);
-
     private static final String INVALID_RPM_ID_ERROR_MESSAGE = "Error fetching remote products from Test Remote Product Manager!";
     private static final String MISSING_RPM_ERROR_MESSAGE = "Remote Product Manager with id null not found!";
     private static final String INVALID_RPM_ID_ERROR_MESSAGE_FIND_BY_ID = "Error fetching remote product with scope id " + TEST_PRODUCT1_SCOPE1 + " from Test Remote Product Manager!";
@@ -68,9 +68,14 @@ public class ProductControllerUnitTest {
 
     private static final List<RemoteProductInfo> TEST_PRODUCT1_REMOTE_PRODUCT_INFO_LIST = new ArrayList<RemoteProductInfo>(Arrays.asList(TEST_REMOTE_PRODUCT_INFO1, TEST_REMOTE_PRODUCT_INFO2));
 
+    private static Instant TEST_INSTANT_NOW = new Date().toInstant();
+    private static Date TEST_CREATED_ON1 = Date.from(TEST_INSTANT_NOW);
+
     private static Product TEST_PRODUCT1 = new Product(TEST_PRODUCT1_NAME, TEST_PRODUCT1_REMOTE_PRODUCT_INFO_LIST);
     private static Product TEST_PRODUCT2 = new Product(TEST_PRODUCT2_NAME);
     private static Product TEST_MODIFIED_PRODUCT = new Product(TEST_MODIFIED_PRODUCT_NAME);
+
+    private static final InternalRequest TEST_REQUEST1 = new InternalRequest(TEST_FEATURE_REQUEST_TITLE, TEST_FEATURE_REQUEST_DESCRIPTION, TEST_PRODUCT1, TEST_CREATED_ON1);
 
     private static TicketRequest TEST_TICKET_REQUEST = new TicketRequest();
 
@@ -117,7 +122,7 @@ public class ProductControllerUnitTest {
         when(remoteProductManagerRepo.findOne(any(Long.class))).thenReturn(TEST_REMOTE_PRODUCT_MANAGER);
         doNothing().when(productRepo).delete(any(Product.class));
         when(sugarService.submit(any(TicketRequest.class))).thenReturn("Successfully submitted issue for test service!");
-        when(internalRequestRepo.create(any(InternalRequest.class))).thenReturn(TEST_REQUEST_NAME);
+        when(internalRequestRepo.create(any(InternalRequest.class))).thenReturn(TEST_REQUEST1);
 
         TEST_PRODUCT1.setId(1L);
         TEST_PRODUCT2.setId(2L);

--- a/src/test/java/edu/tamu/app/model/InternalRequestTest.java
+++ b/src/test/java/edu/tamu/app/model/InternalRequestTest.java
@@ -1,66 +1,85 @@
 package edu.tamu.app.model;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-import java.io.IOException;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.versionone.apiclient.exceptions.APIException;
-import com.versionone.apiclient.exceptions.ConnectionException;
-import com.versionone.apiclient.exceptions.OidException;
-
 import edu.tamu.app.ProductApplication;
-import edu.tamu.app.model.repo.ProductRepo;
+import edu.tamu.app.cache.service.RemoteProductsScheduledCacheService;
+import edu.tamu.app.service.manager.VersionOneService;
+import edu.tamu.app.service.registry.ManagementBeanRegistry;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { ProductApplication.class }, webEnvironment = WebEnvironment.DEFINED_PORT)
 public class InternalRequestTest extends ModelTest {
 
-    @Autowired
-    private ProductRepo productRepo;
+    @Mock
+    private ManagementBeanRegistry managementBeanRegistry;
+
+    @Mock
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    @InjectMocks
+    private RemoteProductsScheduledCacheService remoteProductsScheduledCacheService;
 
     @Before
-    public void setup() throws ConnectionException, APIException, OidException, IOException {
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+
+        VersionOneService versionOneService = mock(VersionOneService.class);
+        when(managementBeanRegistry.getService(any(String.class))).thenReturn(versionOneService);
+
+        remoteProductManagerRepo.create(TEST_REMOTE_PRODUCT_MANAGER1);
         productRepo.create(TEST_PRODUCT);
     }
 
     @Test
     public void testCreate() {
-        InternalRequest internalRequest1 = internalRequestRepo.create(TEST_INTERNAL_REQUEST1);
-        assertEquals("Internal request had incorrect title!", TEST_INTERNAL_REQUEST_TITLE1, internalRequest1.getTitle());
+        Product product = productRepo.findAll().get(0);
+        InternalRequest internalRequest = new InternalRequest(TEST_INTERNAL_REQUEST1.getTitle(), TEST_INTERNAL_REQUEST1.getDescription(), product, TEST_INTERNAL_REQUEST1.getCreatedOn());
+        InternalRequest createdInternalRequest = internalRequestRepo.create(internalRequest);
+        assertEquals("Internal request had incorrect title!", TEST_INTERNAL_REQUEST_TITLE1, createdInternalRequest.getTitle());
     }
 
     @Test
     public void testRead() {
-        internalRequestRepo.create(TEST_INTERNAL_REQUEST1);
+        Product product = productRepo.findAll().get(0);
+        InternalRequest internalRequest = new InternalRequest(TEST_INTERNAL_REQUEST1.getTitle(), TEST_INTERNAL_REQUEST1.getDescription(), product, TEST_INTERNAL_REQUEST1.getCreatedOn());
+
+        internalRequestRepo.create(internalRequest);
         assertEquals("Could not read all internal requests!", 1, internalRequestRepo.findAll().size());
     }
 
     @Test
     public void testUpdate() {
-        InternalRequest internalRequest1 = internalRequestRepo.create(TEST_INTERNAL_REQUEST1);
-        internalRequest1.setTitle(TEST_INTERNAL_REQUEST_TITLE2);
-        internalRequest1 = internalRequestRepo.update(internalRequest1);
-        assertEquals("Internal request did not update title!", TEST_INTERNAL_REQUEST_TITLE2, internalRequest1.getTitle());
+        Product product = productRepo.findAll().get(0);
+        InternalRequest internalRequest = new InternalRequest(TEST_INTERNAL_REQUEST1.getTitle(), TEST_INTERNAL_REQUEST1.getDescription(), product, TEST_INTERNAL_REQUEST1.getCreatedOn());
+        InternalRequest createdInternalRequest = internalRequestRepo.create(internalRequest);
+
+        createdInternalRequest.setTitle(TEST_INTERNAL_REQUEST_TITLE2);
+        createdInternalRequest = internalRequestRepo.update(internalRequest);
+        assertEquals("Internal request did not update title!", TEST_INTERNAL_REQUEST_TITLE2, createdInternalRequest.getTitle());
     }
 
     @Test
     public void testDelete() {
-        InternalRequest internalRequest1 = internalRequestRepo.create(TEST_INTERNAL_REQUEST1);
-        internalRequestRepo.delete(internalRequest1);
+        Product product = productRepo.findAll().get(0);
+        InternalRequest internalRequest = new InternalRequest(TEST_INTERNAL_REQUEST1.getTitle(), TEST_INTERNAL_REQUEST1.getDescription(), product, TEST_INTERNAL_REQUEST1.getCreatedOn());
+        InternalRequest createdInternalRequest = internalRequestRepo.create(internalRequest);
+
+        internalRequestRepo.delete(createdInternalRequest);
         assertEquals("Internal request was not deleted!", 0, internalRequestRepo.count());
     }
-
-    @After
-    public void cleanup() {
-    }
-
 }

--- a/src/test/java/edu/tamu/app/model/InternalRequestTest.java
+++ b/src/test/java/edu/tamu/app/model/InternalRequestTest.java
@@ -2,17 +2,35 @@ package edu.tamu.app.model;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import com.versionone.apiclient.exceptions.APIException;
+import com.versionone.apiclient.exceptions.ConnectionException;
+import com.versionone.apiclient.exceptions.OidException;
+
 import edu.tamu.app.ProductApplication;
+import edu.tamu.app.model.repo.ProductRepo;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = { ProductApplication.class }, webEnvironment = WebEnvironment.DEFINED_PORT)
 public class InternalRequestTest extends ModelTest {
+
+    @Autowired
+    private ProductRepo productRepo;
+
+    @Before
+    public void setup() throws ConnectionException, APIException, OidException, IOException {
+        productRepo.create(TEST_PRODUCT);
+    }
 
     @Test
     public void testCreate() {
@@ -30,7 +48,7 @@ public class InternalRequestTest extends ModelTest {
     public void testUpdate() {
         InternalRequest internalRequest1 = internalRequestRepo.create(TEST_INTERNAL_REQUEST1);
         internalRequest1.setTitle(TEST_INTERNAL_REQUEST_TITLE2);
-        internalRequestRepo.update(TEST_INTERNAL_REQUEST1);
+        internalRequest1 = internalRequestRepo.update(internalRequest1);
         assertEquals("Internal request did not update title!", TEST_INTERNAL_REQUEST_TITLE2, internalRequest1.getTitle());
     }
 
@@ -39,6 +57,10 @@ public class InternalRequestTest extends ModelTest {
         InternalRequest internalRequest1 = internalRequestRepo.create(TEST_INTERNAL_REQUEST1);
         internalRequestRepo.delete(internalRequest1);
         assertEquals("Internal request was not deleted!", 0, internalRequestRepo.count());
+    }
+
+    @After
+    public void cleanup() {
     }
 
 }

--- a/src/test/java/edu/tamu/app/model/InternalStatsTest.java
+++ b/src/test/java/edu/tamu/app/model/InternalStatsTest.java
@@ -11,8 +11,10 @@ public class InternalStatsTest {
 
     @Test
     public void testNewInternalStats() {
-        InternalStats internalStats = new InternalStats(3);
-        assertEquals(3, internalStats.getInternalCount());
+        InternalStats internalStats = new InternalStats(1, 3);
+        assertEquals(2, internalStats.getAssignedCount());
+        assertEquals(1, internalStats.getUnassignedCount());
+        assertEquals(3, internalStats.getTotalCount());
     }
 
 }

--- a/src/test/java/edu/tamu/app/model/ModelTest.java
+++ b/src/test/java/edu/tamu/app/model/ModelTest.java
@@ -23,8 +23,6 @@ public abstract class ModelTest {
 
     protected static final String TEST_ALTERNATE_PRODUCT_NAME = "Alternate Product Name";
 
-    protected static final Product TEST_PRODUCT = new Product(TEST_PRODUCT_NAME);
-
     protected static final String TEST_REMOTE_PRODUCT_MANAGER1_NAME = "Test Remote Product Manager 1";
     protected static final String TEST_REMOTE_PRODUCT_MANAGER2_NAME = "Test Remote Product Manager 2";
 
@@ -52,6 +50,8 @@ public abstract class ModelTest {
 
     protected static final List<RemoteProductInfo> TEST_PRODUCT_REMOTE_PRODUCT_INFO_LIST1 = new ArrayList<RemoteProductInfo>(Arrays.asList(TEST_REMOTE_PRODUCT_INFO1, TEST_REMOTE_PRODUCT_INFO2));
     protected static final List<RemoteProductInfo> TEST_PRODUCT_REMOTE_PRODUCT_INFO_LIST2 = new ArrayList<RemoteProductInfo>(Arrays.asList(TEST_REMOTE_PRODUCT_INFO3));
+
+    protected static final Product TEST_PRODUCT = new Product(TEST_PRODUCT_NAME, TEST_PRODUCT_REMOTE_PRODUCT_INFO_LIST1);
 
     protected static final InternalRequest TEST_INTERNAL_REQUEST1 = new InternalRequest(TEST_INTERNAL_REQUEST_TITLE1, TEST_INTERNAL_REQUEST_DESCRIPTION1, TEST_PRODUCT, TEST_INTERNAL_REQUEST_CREATED_ON1);
     protected static final InternalRequest TEST_INTERNAL_REQUEST2 = new InternalRequest(TEST_INTERNAL_REQUEST_TITLE2, TEST_INTERNAL_REQUEST_DESCRIPTION2, null, TEST_INTERNAL_REQUEST_CREATED_ON2);
@@ -87,10 +87,10 @@ public abstract class ModelTest {
 
     @After
     public void cleanup() {
-        internalRequestRepo.deleteAll();
         statusRepo.deleteAll();
         cardTypeRepo.deleteAll();
         estimateRepo.deleteAll();
+        internalRequestRepo.deleteAll();
         productRepo.deleteAll();
         remoteProductManagerRepo.deleteAll();
     }

--- a/src/test/java/edu/tamu/app/model/ModelTest.java
+++ b/src/test/java/edu/tamu/app/model/ModelTest.java
@@ -23,6 +23,8 @@ public abstract class ModelTest {
 
     protected static final String TEST_ALTERNATE_PRODUCT_NAME = "Alternate Product Name";
 
+    protected static final Product TEST_PRODUCT = new Product(TEST_PRODUCT_NAME);
+
     protected static final String TEST_REMOTE_PRODUCT_MANAGER1_NAME = "Test Remote Product Manager 1";
     protected static final String TEST_REMOTE_PRODUCT_MANAGER2_NAME = "Test Remote Product Manager 2";
 
@@ -51,8 +53,8 @@ public abstract class ModelTest {
     protected static final List<RemoteProductInfo> TEST_PRODUCT_REMOTE_PRODUCT_INFO_LIST1 = new ArrayList<RemoteProductInfo>(Arrays.asList(TEST_REMOTE_PRODUCT_INFO1, TEST_REMOTE_PRODUCT_INFO2));
     protected static final List<RemoteProductInfo> TEST_PRODUCT_REMOTE_PRODUCT_INFO_LIST2 = new ArrayList<RemoteProductInfo>(Arrays.asList(TEST_REMOTE_PRODUCT_INFO3));
 
-    protected static final InternalRequest TEST_INTERNAL_REQUEST1 = new InternalRequest(TEST_INTERNAL_REQUEST_TITLE1, TEST_INTERNAL_REQUEST_DESCRIPTION1, TEST_INTERNAL_REQUEST_CREATED_ON1);
-    protected static final InternalRequest TEST_INTERNAL_REQUEST2 = new InternalRequest(TEST_INTERNAL_REQUEST_TITLE2, TEST_INTERNAL_REQUEST_DESCRIPTION2, TEST_INTERNAL_REQUEST_CREATED_ON2);
+    protected static final InternalRequest TEST_INTERNAL_REQUEST1 = new InternalRequest(TEST_INTERNAL_REQUEST_TITLE1, TEST_INTERNAL_REQUEST_DESCRIPTION1, TEST_PRODUCT, TEST_INTERNAL_REQUEST_CREATED_ON1);
+    protected static final InternalRequest TEST_INTERNAL_REQUEST2 = new InternalRequest(TEST_INTERNAL_REQUEST_TITLE2, TEST_INTERNAL_REQUEST_DESCRIPTION2, null, TEST_INTERNAL_REQUEST_CREATED_ON2);
 
     @Autowired
     protected StatusRepo statusRepo;

--- a/src/test/java/edu/tamu/app/model/ModelTest.java
+++ b/src/test/java/edu/tamu/app/model/ModelTest.java
@@ -87,6 +87,7 @@ public abstract class ModelTest {
 
     @After
     public void cleanup() {
+        internalRequestRepo.deleteAll();
         statusRepo.deleteAll();
         cardTypeRepo.deleteAll();
         estimateRepo.deleteAll();

--- a/src/test/java/edu/tamu/app/service/manager/CacheMockTests.java
+++ b/src/test/java/edu/tamu/app/service/manager/CacheMockTests.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.tamu.app.cache.model.RemoteProduct;
 import edu.tamu.app.cache.model.Sprint;
+import edu.tamu.app.model.InternalRequest;
 
 public abstract class CacheMockTests {
 
@@ -22,6 +23,9 @@ public abstract class CacheMockTests {
 
     @Value("classpath:mock/cache/remote-products.json")
     private Resource remoteProducts;
+
+    @Value("classpath:mock/cache/internal-requests.json")
+    private Resource internalRequests;
 
     @Spy
     private ObjectMapper objectMapper;
@@ -33,6 +37,10 @@ public abstract class CacheMockTests {
 
     protected List<RemoteProduct> getMockRemoteProducts() throws JsonParseException, JsonMappingException, IOException {
         return objectMapper.readValue(remoteProducts.getFile(), new TypeReference<List<RemoteProduct>>() {});
+    }
+
+    protected List<InternalRequest> getMockInternalRequests() throws JsonParseException, JsonMappingException, IOException {
+        return objectMapper.readValue(internalRequests.getFile(), new TypeReference<List<InternalRequest>>() {});
     }
     // @formatter:on
 

--- a/src/test/resources/mock/cache/internal-requests.json
+++ b/src/test/resources/mock/cache/internal-requests.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": 1,
+    "title": "Example Internal Request 1",
+    "description": "This is a mocked internal request.",
+    "productId": 1,
+    "createdOn": 1588262229449
+  }, {
+    "id": 2,
+    "title": "Example Internal Request 2",
+    "description": "This is a mocked internal request without a productId.",
+    "productId": null,
+    "createdOn": 1588262230449
+  }
+]


### PR DESCRIPTION
Always associate the product received by remote products such as LSSS.
This requires redesigning the Service and UI to associate with a given product.
Whereas before, the product was only associated on push, the product is now associated on create/edit.

Resolves #86