### PR TITLE
Issue 95: username/password for GitHub should be removed - no longer available

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,9 @@
               <ignore>java.util.logging.*</ignore>
               <ignore>edu.tamu.app.config.AppEmailConfig</ignore>
             </ignores>
+            <excludes>
+              <exclude>**/ProjectInitialization.class</exclude>
+            </excludes>
           </instrumentation>
           <formats>
             <format>html</format>
@@ -173,6 +176,11 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/ProjectInitialization.class</exclude>
+          </excludes>
+        </configuration>
         <executions>
           <execution>
             <id>prepare-agent</id>

--- a/src/main/java/edu/tamu/app/ProjectInitialization.java
+++ b/src/main/java/edu/tamu/app/ProjectInitialization.java
@@ -40,7 +40,7 @@ public class ProjectInitialization implements CommandLineRunner {
                 if (!versionManagementSoftware.getSettingValue("url").isPresent()) {
                     return;
                 }
-                
+
                 if (versionManagementSoftware.getSettingValue("url").get().isEmpty()) {
                     return;
                 }

--- a/src/main/java/edu/tamu/app/ProjectInitialization.java
+++ b/src/main/java/edu/tamu/app/ProjectInitialization.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import edu.tamu.app.model.CardType;
+import edu.tamu.app.model.ServiceType;
 import edu.tamu.app.model.repo.CardTypeRepo;
 import edu.tamu.app.model.repo.RemoteProjectManagerRepo;
 import edu.tamu.app.service.registry.ManagementBeanRegistry;
@@ -29,6 +30,22 @@ public class ProjectInitialization implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         remoteProjectManagerRepo.findAll().forEach(versionManagementSoftware -> {
+            if (versionManagementSoftware.getType().equals(ServiceType.GITHUB)) {
+                if (!versionManagementSoftware.getSettingValue("token").isPresent()) {
+                    return;
+                }
+            }
+
+            if (versionManagementSoftware.getType().equals(ServiceType.VERSION_ONE)) {
+                if (!versionManagementSoftware.getSettingValue("url").isPresent()) {
+                    return;
+                }
+                
+                if (versionManagementSoftware.getSettingValue("url").get().isEmpty()) {
+                    return;
+                }
+            }
+
             managementBeanRegistry.register(versionManagementSoftware);
         });
         CardType type = cardTypeRepo.findByIdentifier("Feature");

--- a/src/main/java/edu/tamu/app/model/ServiceType.java
+++ b/src/main/java/edu/tamu/app/model/ServiceType.java
@@ -40,6 +40,9 @@ public enum ServiceType {
         List<Setting> scaffold = new ArrayList<Setting>();
         switch (this) {
         case GITHUB:
+            scaffold.add(new Setting("text", "url", "URL", true));
+            scaffold.add(new Setting("password", "token", "Token", false));
+            break;
         case VERSION_ONE:
             scaffold.add(new Setting("text", "url", "URL", true));
             scaffold.add(new Setting("text", "username", "Username", false));

--- a/src/main/java/edu/tamu/app/service/manager/GitHubService.java
+++ b/src/main/java/edu/tamu/app/service/manager/GitHubService.java
@@ -135,7 +135,7 @@ public class GitHubService extends MappingRemoteProjectManagerBean {
         final Optional<String> endpoint = managementService.getSettingValue("url");
         final Optional<String> token = managementService.getSettingValue("token");
         if (!endpoint.isPresent()) {
-            throw new RuntimeException("GitHub service enpoint was not defined");
+            throw new RuntimeException("GitHub service endpoint was not defined");
         }
         if (!token.isPresent()) {
             throw new RuntimeException("GitHub token was not defined");

--- a/src/main/java/edu/tamu/app/service/manager/GitHubService.java
+++ b/src/main/java/edu/tamu/app/service/manager/GitHubService.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueState;
@@ -40,7 +39,6 @@ import edu.tamu.app.cache.model.RemoteProject;
 import edu.tamu.app.cache.model.Sprint;
 import edu.tamu.app.model.ManagementService;
 import edu.tamu.app.model.request.FeatureRequest;
-import edu.tamu.app.rest.BasicAuthRestTemplate;
 import edu.tamu.app.rest.TokenAuthRestTemplate;
 
 public class GitHubService extends MappingRemoteProjectManagerBean {
@@ -134,24 +132,18 @@ public class GitHubService extends MappingRemoteProjectManagerBean {
     }
 
     protected GitHub getGitHubInstance() throws IOException {
-        GitHub githubInstance;
         final Optional<String> endpoint = managementService.getSettingValue("url");
         final Optional<String> token = managementService.getSettingValue("token");
         if (!endpoint.isPresent()) {
             throw new RuntimeException("GitHub service enpoint was not defined");
         }
-        if (token.isPresent()) {
-            githubInstance = ghBuilder
-                .withEndpoint(endpoint.get())
-                .withOAuthToken(token.get())
-                .build();
-        } else {
-            githubInstance = ghBuilder
-                .withEndpoint(endpoint.get())
-                .withPassword(getSettingValue("username"), getSettingValue("password"))
-                .build();
+        if (!token.isPresent()) {
+            throw new RuntimeException("GitHub token was not defined");
         }
-        return githubInstance;
+        return ghBuilder
+            .withEndpoint(endpoint.get())
+            .withOAuthToken(token.get())
+            .build();
     }
 
     private String getSettingValue(final String key) {
@@ -164,8 +156,7 @@ public class GitHubService extends MappingRemoteProjectManagerBean {
     }
 
     private RestTemplate getRestTemplate() {
-        String token = getSettingValue("token");
-        return StringUtils.isNotBlank(token) ? new TokenAuthRestTemplate(token) : new BasicAuthRestTemplate(getSettingValue("username"), getSettingValue("password"));
+        return new TokenAuthRestTemplate(getSettingValue("token"));
     }
 
     private RemoteProject buildRemoteProject(GHRepository repo, List<GHLabel> labels) throws IOException {

--- a/src/test/java/edu/tamu/app/model/ModelTest.java
+++ b/src/test/java/edu/tamu/app/model/ModelTest.java
@@ -75,6 +75,20 @@ public abstract class ModelTest {
     protected InternalRequestRepo internalRequestRepo;
 
     protected static Map<String, String> getMockSettings() {
+        return getMockSettings(false);
+    }
+
+    protected static Map<String, String> getMockSettings(boolean token) {
+        if (token) {
+            return new HashMap<String, String>() {
+                private static final long serialVersionUID = 2020874481642498007L;
+                {
+                    put("url", "https://localhost:9101/TexasAMLibrary");
+                    put("token", "token");
+                }
+            };
+        }
+        
         return new HashMap<String, String>() {
             private static final long serialVersionUID = 2020874481642498006L;
             {

--- a/src/test/java/edu/tamu/app/model/RemoteProjectManagerTest.java
+++ b/src/test/java/edu/tamu/app/model/RemoteProjectManagerTest.java
@@ -23,15 +23,16 @@ public class RemoteProjectManagerTest extends ModelTest {
     @Test
     public void testCreate() {
         Map<String, String> settings = getMockSettings();
+        Map<String, String> settingsToken = getMockSettings(true);
         RemoteProjectManager remoteProjectManager1 = remoteProjectManagerRepo.create(new RemoteProjectManager(TEST_REMOTE_PROJECT_MANAGER1_NAME, ServiceType.VERSION_ONE, settings));
-        RemoteProjectManager remoteProjectManager2 = remoteProjectManagerRepo.create(new RemoteProjectManager(TEST_REMOTE_PROJECT_MANAGER2_NAME, ServiceType.GITHUB, settings));
+        RemoteProjectManager remoteProjectManager2 = remoteProjectManagerRepo.create(new RemoteProjectManager(TEST_REMOTE_PROJECT_MANAGER2_NAME, ServiceType.GITHUB, settingsToken));
         assertEquals("Remote project manager repo had incorrect number of remote project managers!", 2, remoteProjectManagerRepo.count());
         assertEquals("Remote project manager had incorrect name!", TEST_REMOTE_PROJECT_MANAGER1_NAME, remoteProjectManager1.getName());
         assertEquals("Remote project manager had incorrect service type!", ServiceType.VERSION_ONE, remoteProjectManager1.getType());
         assertEquals("Remote project manager had incorrect settings!", settings, remoteProjectManager1.getSettings());
         assertEquals("Remote project manager had incorrect name!", TEST_REMOTE_PROJECT_MANAGER2_NAME, remoteProjectManager2.getName());
         assertEquals("Remote project manager had incorrect service type!", ServiceType.GITHUB, remoteProjectManager2.getType());
-        assertEquals("Remote project manager had incorrect settings!", settings, remoteProjectManager2.getSettings());
+        assertEquals("Remote project manager had incorrect settings!", settingsToken, remoteProjectManager2.getSettings());
     }
 
     @Test

--- a/src/test/java/edu/tamu/app/service/manager/GitHubServiceTest.java
+++ b/src/test/java/edu/tamu/app/service/manager/GitHubServiceTest.java
@@ -396,6 +396,44 @@ public class GitHubServiceTest extends CacheMockTests {
     }
 
     @Test
+    public void testGetGitHubInstanceWithInvalidServiceEndpoint() throws IOException {
+        ManagementService invalidManagementService = new RemoteProjectManager("GitHub", ServiceType.GITHUB,
+        new HashMap<String, String>() {
+            private static final long serialVersionUID = 2020874481642498006L;
+            {
+                put("token", "token");
+            }
+        });
+
+        setField(gitHubService, "managementService", invalidManagementService);
+
+        try {
+            gitHubService.getGitHubInstance();
+        } catch (RuntimeException e) {
+            assertEquals(e.getMessage(), "GitHub service endpoint was not defined");
+        }
+    }
+
+    @Test
+    public void testGetGitHubInstanceWithInvalidToken() throws IOException {
+        ManagementService invalidManagementService = new RemoteProjectManager("GitHub", ServiceType.GITHUB,
+        new HashMap<String, String>() {
+            private static final long serialVersionUID = 2020874481642498006L;
+            {
+                put("url", "https://localhost:9101/TexasAMLibrary");
+            }
+        });
+
+        setField(gitHubService, "managementService", invalidManagementService);
+
+        try {
+            gitHubService.getGitHubInstance();
+        } catch (RuntimeException e) {
+            assertEquals(e.getMessage(), "GitHub token was not defined");
+        }
+    }
+
+    @Test
     public void testGetGitHubInstanceByToken() throws IOException {
         GitHub gitHubInstance = gitHubService.getGitHubInstance();
         assertNotNull("GitHub object was not created", gitHubInstance);

--- a/src/test/java/edu/tamu/app/service/manager/GitHubServiceTest.java
+++ b/src/test/java/edu/tamu/app/service/manager/GitHubServiceTest.java
@@ -173,14 +173,14 @@ public class GitHubServiceTest extends CacheMockTests {
     @Before
     public void setUp() throws Exception {
         ManagementService managementService = new RemoteProjectManager("GitHub", ServiceType.GITHUB,
-                new HashMap<String, String>() {
-                    private static final long serialVersionUID = 2020874481642498006L;
-                    {
-                        put("url", "https://localhost:9101/TexasAMLibrary");
-                        put("username", "username");
-                        put("password", "password");
-                    }
-                });
+            new HashMap<String, String>() {
+                private static final long serialVersionUID = 2020874481642498006L;
+                {
+                    put("url", "https://localhost:9101/TexasAMLibrary");
+                    put("token", "token");
+                }
+            });
+
 
         CardTypeRepo cardTypeRepo = mock(CardTypeRepo.class);
         StatusRepo statusRepo = mock(StatusRepo.class);
@@ -199,7 +199,6 @@ public class GitHubServiceTest extends CacheMockTests {
         github = mock(GitHub.class);
 
         when(ghBuilder.withEndpoint(any(String.class))).thenReturn(ghBuilder);
-        when(ghBuilder.withPassword(any(String.class), any(String.class))).thenReturn(ghBuilder);
         when(ghBuilder.withOAuthToken(any(String.class))).thenReturn(ghBuilder);
         when(ghBuilder.build()).thenReturn(github);
 
@@ -397,24 +396,7 @@ public class GitHubServiceTest extends CacheMockTests {
     }
 
     @Test
-    public void testGetGitHubInstanceByPassword() throws IOException {
-        GitHub githubInstance = gitHubService.getGitHubInstance();
-        assertNotNull("GitHub object was not created", githubInstance);
-    }
-
-    @Test
     public void testGetGitHubInstanceByToken() throws IOException {
-        ManagementService tokenManagementService = new RemoteProjectManager("GitHub", ServiceType.GITHUB,
-                new HashMap<String, String>() {
-                    private static final long serialVersionUID = 2020874481642498006L;
-                    {
-                        put("url", "https://localhost:9101/TexasAMLibrary");
-                        put("token", "token");
-                    }
-                });
-
-        setField(gitHubService, "managementService", tokenManagementService);
-
         GitHub gitHubInstance = gitHubService.getGitHubInstance();
         assertNotNull("GitHub object was not created", gitHubInstance);
     }


### PR DESCRIPTION
With GITHUB no longer needing the username/password, remove these fields from the scaffold but only for GITHUB.

With this change, existing data may now be in an invalid state.

The getGitHubInstance() function has the username/password instance builder removed and now instead throws an exception when the token is not present.
The getRestTemplate() function now only handles "token" and the TokenAuthRestTemplate() already handles throwing exceptions on invalid "token".

It turns out that when this invalid state exists, the service will not start.
This addresses the issue of an unstartable service by preventing the registering of RPMs on start that have the following invalid conditions:
1) If "token" is not available and the type is GITHUB.
2) The "url" is not available and the type is VERSION_ONE.

resolves #95
relates TAMULib/ProjectManagementUI#73