### PR TITLE
Issue 94: Error when trying to push internal request to GitHub

### DIFF
--- a/src/main/java/edu/tamu/app/service/manager/GitHubService.java
+++ b/src/main/java/edu/tamu/app/service/manager/GitHubService.java
@@ -124,13 +124,15 @@ public class GitHubService extends MappingRemoteProjectManagerBean {
     }
 
     @Override
-    public Object push(final FeatureRequest request) throws Exception {
+    public String push(final FeatureRequest request) throws Exception {
         logger.info("Submitting feature request " + request.getTitle() + " to product with scope id " + request.getScopeId());
-        String repoId = String.valueOf(request.getProductId());
+
+        String scopeId = String.valueOf(request.getScopeId());
         String title = request.getTitle();
         String body = request.getDescription();
-        GHRepository repo = github.getRepositoryById(repoId);
-        return repo.createIssue(title).body(body).create();
+        GHRepository repo = github.getRepositoryById(scopeId);
+
+        return Long.toString(repo.createIssue(title).body(body).create().getId());
     }
 
     protected GitHub getGitHubInstance() throws IOException {

--- a/src/main/java/edu/tamu/app/service/manager/RemoteProjectManagerBean.java
+++ b/src/main/java/edu/tamu/app/service/manager/RemoteProjectManagerBean.java
@@ -17,6 +17,6 @@ public interface RemoteProjectManagerBean extends ManagementBean {
 
     public List<Sprint> getAdditionalActiveSprints() throws Exception;
 
-    public Object push(final FeatureRequest request) throws Exception;
+    public String push(final FeatureRequest request) throws Exception;
 
 }

--- a/src/main/java/edu/tamu/app/service/manager/VersionOneService.java
+++ b/src/main/java/edu/tamu/app/service/manager/VersionOneService.java
@@ -269,7 +269,7 @@ public class VersionOneService extends MappingRemoteProjectManagerBean {
     }
 
     @Override
-    public Object push(FeatureRequest featureRequest) throws V1Exception {
+    public String push(FeatureRequest featureRequest) throws V1Exception {
         logger.info("Submitting feature request " + featureRequest.getTitle() + " to product with scope id " + featureRequest.getScopeId());
         IAssetType requestType = services.getMeta().getAssetType("Request");
         IAttributeDefinition nameAttributeDefinition = requestType.getAttributeDefinition("Name");
@@ -286,7 +286,7 @@ public class VersionOneService extends MappingRemoteProjectManagerBean {
 
         services.save(request);
 
-        return request;
+        return request.getOid().getToken();
     }
 
     private void clearMembers() {

--- a/src/test/java/edu/tamu/app/controller/InternalRequestControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/InternalRequestControllerTest.java
@@ -123,7 +123,7 @@ public class InternalRequestControllerTest {
         when(internalRequestRepo.countByProductIsNull()).thenReturn(1L);
         when(internalRequestRepo.create(any(InternalRequest.class))).thenReturn(TEST_REQUEST_BELLS);
         when(internalRequestRepo.update(any(InternalRequest.class))).thenReturn(TEST_REQUEST_BELLS);
-        when(remoteProjectManagementBean.push(any(FeatureRequest.class))).thenReturn(TEST_FEATURE_REQUEST);
+        when(remoteProjectManagementBean.push(any(FeatureRequest.class))).thenReturn("1");
         when(managementBeanRegistry.getService(any(String.class))).thenReturn(remoteProjectManagementBean);
 
         doAnswer(new Answer<ApiResponse>() {

--- a/src/test/java/edu/tamu/app/controller/ProductControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/ProductControllerTest.java
@@ -203,7 +203,7 @@ public class ProductControllerTest {
 
     @Test
     public void testPushRequest() throws Exception {
-        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn(TEST_FEATURE_REQUEST);
+        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn(TEST_FEATURE_REQUEST.getScopeId());
         when(managementBeanRegistry.getService(any(String.class))).thenReturn(remoteProjectManagementBean);
         when(productRepo.findOne(any(Long.class))).thenReturn(TEST_PRODUCT1);
         apiResponse = productController.pushRequest(TEST_FEATURE_REQUEST);
@@ -212,7 +212,7 @@ public class ProductControllerTest {
 
     @Test
     public void testGetAllRemoteProductsForProduct() throws Exception {
-        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn(TEST_FEATURE_REQUEST);
+        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn(TEST_FEATURE_REQUEST.getScopeId());
         when(managementBeanRegistry.getService(any(String.class))).thenReturn(remoteProjectManagementBean);
         when(productRepo.findOne(any(Long.class))).thenReturn(TEST_PRODUCT1);
         apiResponse = productController.getAllRemoteProjectsForProduct(TEST_PRODUCT1.getId());
@@ -221,7 +221,7 @@ public class ProductControllerTest {
 
     @Test
     public void testGetAllRemoteProductsForProductWithInvalidId() throws Exception {
-        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn(TEST_FEATURE_REQUEST);
+        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn(TEST_FEATURE_REQUEST.getScopeId());
         when(managementBeanRegistry.getService(any(String.class))).thenReturn(remoteProjectManagementBean);
         apiResponse = productController.getAllRemoteProjectsForProduct(null);
         assertEquals("Request with invalid Product id did not result in an error", ERROR, apiResponse.getMeta().getStatus());
@@ -240,7 +240,7 @@ public class ProductControllerTest {
     @Test
     public void testGetAllRemoteProjects() throws Exception {
         when(remoteProjectManagerRepo.findOne(any(Long.class))).thenReturn(testRemoteProjectManagerOne);
-        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn(TEST_FEATURE_REQUEST);
+        when(remoteProjectManagementBean.push(TEST_FEATURE_REQUEST)).thenReturn("1");
         when(managementBeanRegistry.getService(any(String.class))).thenReturn(remoteProjectManagementBean);
         apiResponse = productController.getAllRemoteProjects(testRemoteProjectManagerOne.getId());
         assertEquals("Remote Project Manager controller unable to get all remote projects", SUCCESS, apiResponse.getMeta().getStatus());

--- a/src/test/java/edu/tamu/app/service/manager/GitHubServiceTest.java
+++ b/src/test/java/edu/tamu/app/service/manager/GitHubServiceTest.java
@@ -384,8 +384,8 @@ public class GitHubServiceTest extends CacheMockTests {
 
     @Test
     public void testPush() throws Exception {
-        GHIssue issue = (GHIssue) gitHubService.push(TEST_FEATURE_REQUEST);
-        assertEquals("Didn't get expected issue", TEST_ISSUE1, issue);
+        String id = gitHubService.push(TEST_FEATURE_REQUEST);
+        assertNotNull(id);
     }
 
     @Test

--- a/src/test/java/edu/tamu/app/service/manager/VersionOneServiceTest.java
+++ b/src/test/java/edu/tamu/app/service/manager/VersionOneServiceTest.java
@@ -240,6 +240,7 @@ public class VersionOneServiceTest extends CacheMockTests {
     @Test
     public void testGetRemoteProductByScopeId() throws ConnectionException, APIException, OidException, JsonParseException, JsonMappingException, IOException {
         Oid oid = mock(Oid.class);
+
         QueryResult result = mock(QueryResult.class);
         IMetaModel metaModel = mock(IMetaModel.class);
         IAssetType scopeType = mock(IAssetType.class);
@@ -499,6 +500,7 @@ public class VersionOneServiceTest extends CacheMockTests {
     @Test
     public void testGetMember() throws JsonParseException, JsonMappingException, APIException, IOException, OidException, ConnectionException {
         Oid oid = mock(Oid.class);
+
         QueryResult result = mock(QueryResult.class);
         IMetaModel metaModel = mock(IMetaModel.class);
         IAssetType memberType = mock(IAssetType.class);
@@ -545,6 +547,7 @@ public class VersionOneServiceTest extends CacheMockTests {
     @Test
     public void testGetMemberWithAvatarImage() throws JsonParseException, JsonMappingException, APIException, IOException, OidException, ConnectionException {
         Oid oid = mock(Oid.class);
+
         QueryResult result = mock(QueryResult.class);
         IMetaModel metaModel = mock(IMetaModel.class);
         IAssetType memberType = mock(IAssetType.class);
@@ -591,6 +594,8 @@ public class VersionOneServiceTest extends CacheMockTests {
     @Test
     public void testPush() throws V1Exception {
         Oid oid = mock(Oid.class);
+        Oid assetOid = mock(Oid.class);
+
         IMetaModel metaModel = mock(IMetaModel.class);
         IAssetType assetType = mock(IAssetType.class);
         IAttributeDefinition attributeDefinition = mock(IAttributeDefinition.class);
@@ -599,10 +604,13 @@ public class VersionOneServiceTest extends CacheMockTests {
 
         when(assetType.getAttributeDefinition(any(String.class))).thenReturn(attributeDefinition);
         when(metaModel.getAssetType(any(String.class))).thenReturn(assetType);
+
         when(services.getOid(any(String.class))).thenReturn(oid);
         when(services.getMeta()).thenReturn(metaModel);
-
         when(services.createNew(any(IAssetType.class), any(Oid.class))).thenReturn(mockAsset);
+
+        when(mockAsset.getOid()).thenReturn(assetOid);
+        when(assetOid.getToken()).thenReturn("token:assetOid");
 
         doNothing().when(mockAsset).setAttributeValue(any(IAttributeDefinition.class), any(Object.class));
 
@@ -912,8 +920,13 @@ public class VersionOneServiceTest extends CacheMockTests {
         when(mockAvatarAttribute.getDefinition()).thenReturn(avatarAttributeDefinition);
 
         Oid oid = mock(Oid.class);
+        Oid assetOid = mock(Oid.class);
+
         when(oid.toString()).thenReturn(withImage ? "Image:" + member.getId() : "NULL");
         when(mockAvatarAttribute.getValue()).thenReturn(oid);
+
+        when(mockAsset.getOid()).thenReturn(assetOid);
+        when(assetOid.getToken()).thenReturn("token:assetOid");
 
         when(mockAsset.getAttribute(any(IAttributeDefinition.class))).thenAnswer(new Answer<Attribute>() {
             @Override


### PR DESCRIPTION
Trying to push githubs (and versionones) models to our service generates this error.
Instead, just return the ID as a string.
A string is used because versionone, github, and in theory anything else may utilize different ids.

resolves #94 
resolves #82