### PR TITLE
Issue 96: By default, map cards in an unmapped GitHub Project column to "In Progress"

### DIFF
--- a/src/main/java/edu/tamu/app/mapping/StatusMappingService.java
+++ b/src/main/java/edu/tamu/app/mapping/StatusMappingService.java
@@ -10,7 +10,7 @@ public class StatusMappingService extends AbstractRepoMappingService<String, Str
 
     @Override
     public String handleUnmapped(String rawData) {
-        return rawData == null ? "None" : rawData;
+        return rawData == null ? "None" : "In Progress";
     }
 
 }


### PR DESCRIPTION
The map was using the unmapped value by default.
Just change that to "In Progress".

The case where the map string is NULL, preserve the existing behavior where it gets set to "None".

resolves #96