### PR TITLE
Issue 115: Cleanup ServiceType Scaffolding

### DIFF
--- a/src/main/java/edu/tamu/app/controller/RemoteProjectManagerController.java
+++ b/src/main/java/edu/tamu/app/controller/RemoteProjectManagerController.java
@@ -76,11 +76,4 @@ public class RemoteProjectManagerController {
     public ApiResponse getTypes() {
         return new ApiResponse(SUCCESS, ServiceType.map());
     }
-
-    @GetMapping("/scaffolding/{type}")
-    @PreAuthorize("hasRole('USER')")
-    public ApiResponse getTypeScaffolding(@PathVariable String type) {
-        ServiceType serviceType = ServiceType.valueOf(type);
-        return new ApiResponse(SUCCESS, serviceType.getScaffold());
-    }
 }

--- a/src/main/java/edu/tamu/app/model/ServiceType.java
+++ b/src/main/java/edu/tamu/app/model/ServiceType.java
@@ -19,7 +19,6 @@ public enum ServiceType {
             Map<String, Object> m = new HashMap<String, Object>();
             m.put("value", type.toString());
             m.put("gloss", type.gloss);
-            m.put("scaffold", type.getScaffold());
             list.add(m);
         }
     }
@@ -34,26 +33,6 @@ public enum ServiceType {
 
     public void setGloss(String gloss) {
         this.gloss = gloss;
-    }
-
-    public List<Setting> getScaffold() {
-        List<Setting> scaffold = new ArrayList<Setting>();
-        switch (this) {
-        case GITHUB:
-            scaffold.add(new Setting("text", "url", "URL", true));
-            scaffold.add(new Setting("password", "token", "Token", false));
-            break;
-        case VERSION_ONE:
-            scaffold.add(new Setting("text", "url", "URL", true));
-            scaffold.add(new Setting("text", "username", "Username", false));
-            scaffold.add(new Setting("password", "password", "Password", false));
-            scaffold.add(new Setting("password", "token", "Token", false));
-            break;
-        default:
-            break;
-
-        }
-        return scaffold;
     }
 
     public static List<Map<String, Object>> map() {

--- a/src/test/java/edu/tamu/app/controller/RemoteProjectManagerControllerTest.java
+++ b/src/test/java/edu/tamu/app/controller/RemoteProjectManagerControllerTest.java
@@ -136,10 +136,4 @@ public class RemoteProjectManagerControllerTest {
         assertEquals("Not successful at getting service types", SUCCESS, response.getMeta().getStatus());
     }
 
-    @Test
-    public void testGetScaffolding() {
-        ApiResponse response = remoteProjectManagerController.getTypeScaffolding(ServiceType.VERSION_ONE.toString());
-        assertEquals("Not successful at getting scaffolding", SUCCESS, response.getMeta().getStatus());
-    }
-
 }


### PR DESCRIPTION
There is no longer a settings array.
The username/password do not exist anymore.
The URL and token are now directly on the model.

resolves #115 