### PR TITLE
Issue 111: NULL Pointer exceptions on startup

### DIFF
--- a/src/main/java/edu/tamu/app/ProjectInitialization.java
+++ b/src/main/java/edu/tamu/app/ProjectInitialization.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
@@ -30,8 +31,8 @@ public class ProjectInitialization implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         remoteProjectManagerRepo.findAll().forEach(versionManagementSoftware -> {
-            if (Optional.ofNullable(versionManagementSoftware.getUrl()).isPresent()) {
-                if (Optional.ofNullable(versionManagementSoftware.getToken()).isPresent()) {
+            if (StringUtils.isNotEmpty(versionManagementSoftware.getUrl())) {
+                if (StringUtils.isNotEmpty(versionManagementSoftware.getToken())) {
                     managementBeanRegistry.register(versionManagementSoftware);
                 }
             }

--- a/src/main/java/edu/tamu/app/ProjectInitialization.java
+++ b/src/main/java/edu/tamu/app/ProjectInitialization.java
@@ -2,7 +2,6 @@ package edu.tamu.app;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/edu/tamu/app/ProjectInitialization.java
+++ b/src/main/java/edu/tamu/app/ProjectInitialization.java
@@ -30,15 +30,11 @@ public class ProjectInitialization implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         remoteProjectManagerRepo.findAll().forEach(versionManagementSoftware -> {
-            if (Optional.ofNullable( versionManagementSoftware.getUrl()).isPresent()) {
-                return;
+            if (Optional.ofNullable(versionManagementSoftware.getUrl()).isPresent()) {
+                if (Optional.ofNullable(versionManagementSoftware.getToken()).isPresent()) {
+                    managementBeanRegistry.register(versionManagementSoftware);
+                }
             }
-
-            if (Optional.ofNullable( versionManagementSoftware.getToken()).isPresent()) {
-                return;
-            }
-
-            managementBeanRegistry.register(versionManagementSoftware);
         });
         CardType type = cardTypeRepo.findByIdentifier("Feature");
         HashSet<String> featureTypes = new HashSet<String>(Arrays.asList(new String[] { "Story", "feature" }));


### PR DESCRIPTION
The boolean logic is reversed, resulting in the NULL pointer exception on startup.
This also seems to prevent the cache from working after startup for existing Remote Projects.
(Newly created Remote Projects will cache properly.)

Also change the logic to use nested if conditions instead of `return` appears to solve the problem.

resolves #111 