### PR TITLE
[Sprint7] [80] Add ServiceType as 'type' to Sprint and related to help achieve icon generation.

### DIFF
--- a/src/main/java/edu/tamu/app/cache/model/Sprint.java
+++ b/src/main/java/edu/tamu/app/cache/model/Sprint.java
@@ -4,6 +4,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.tamu.app.model.ServiceType;
+
 public class Sprint implements Serializable {
 
     private static final long serialVersionUID = -1490373427353614907L;
@@ -14,6 +16,8 @@ public class Sprint implements Serializable {
 
     private final String product;
 
+    private final String type;
+
     private final List<Card> cards;
 
     public Sprint() {
@@ -21,14 +25,16 @@ public class Sprint implements Serializable {
         this.id = "";
         this.name = "";
         this.product = "";
+        this.type = "";
         this.cards = new ArrayList<Card>();
     }
 
-    public Sprint(String id, String name, String product, List<Card> cards) {
+    public Sprint(String id, String name, String product, String type, List<Card> cards) {
         super();
         this.id = id;
         this.name = name;
         this.product = product;
+        this.type = type;
         this.cards = cards;
     }
 
@@ -42,6 +48,10 @@ public class Sprint implements Serializable {
 
     public String getProduct() {
         return product;
+    }
+
+    public String getType() {
+        return type;
     }
 
     public List<Card> getCards() {

--- a/src/main/java/edu/tamu/app/service/manager/GitHubMilestoneService.java
+++ b/src/main/java/edu/tamu/app/service/manager/GitHubMilestoneService.java
@@ -19,6 +19,7 @@ import org.kohsuke.github.GHRepository;
 import edu.tamu.app.cache.model.Card;
 import edu.tamu.app.cache.model.Sprint;
 import edu.tamu.app.model.ManagementService;
+import edu.tamu.app.model.ServiceType;
 
 public class GitHubMilestoneService extends AbstractGitHubService {
 
@@ -49,7 +50,8 @@ public class GitHubMilestoneService extends AbstractGitHubService {
     private Stream<Sprint> getActiveSprintsForProject(GHProject project, String product, int count) {
         String sprintId = String.format("%s-%s", project.getId(), count);
         return exceptionHandlerWrapper(project, p -> getCards(p).entrySet()).stream()
-            .map(e -> new Sprint(sprintId, e.getKey(), product, e.getValue()));
+            .map(e -> new Sprint(sprintId, e.getKey(), product,
+                ServiceType.GITHUB_MILESTONE.toString(), e.getValue()));
     }
 
     private Map<String, List<Card>> getCards(GHProject project) throws IOException {

--- a/src/main/java/edu/tamu/app/service/manager/GitHubProjectService.java
+++ b/src/main/java/edu/tamu/app/service/manager/GitHubProjectService.java
@@ -13,6 +13,7 @@ import org.kohsuke.github.GHRepository;
 import edu.tamu.app.cache.model.Card;
 import edu.tamu.app.cache.model.Sprint;
 import edu.tamu.app.model.ManagementService;
+import edu.tamu.app.model.ServiceType;
 
 public class GitHubProjectService extends AbstractGitHubService {
 
@@ -49,6 +50,7 @@ public class GitHubProjectService extends AbstractGitHubService {
             String.valueOf(project.getId()),
             toProductName(project),
             productName,
+            ServiceType.GITHUB_PROJECT.toString(),
             getCards(project)
         );
     }

--- a/src/main/java/edu/tamu/app/service/manager/VersionOneService.java
+++ b/src/main/java/edu/tamu/app/service/manager/VersionOneService.java
@@ -45,6 +45,7 @@ import edu.tamu.app.cache.model.Member;
 import edu.tamu.app.cache.model.RemoteProject;
 import edu.tamu.app.cache.model.Sprint;
 import edu.tamu.app.model.ManagementService;
+import edu.tamu.app.model.ServiceType;
 import edu.tamu.app.model.request.FeatureRequest;
 import edu.tamu.app.rest.TokenAuthRestTemplate;
 
@@ -170,7 +171,7 @@ public class VersionOneService extends MappingRemoteProjectManagerBean {
             }
 
             List<Card> cards = getActiveSprintsCards(id);
-            activeSprints.add(new Sprint(id, name, productName, cards));
+            activeSprints.add(new Sprint(id, name, productName, ServiceType.VERSION_ONE.toString(), cards));
         }
         return activeSprints;
     }

--- a/src/test/java/edu/tamu/app/cache/ActiveSprintsCacheTest.java
+++ b/src/test/java/edu/tamu/app/cache/ActiveSprintsCacheTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import edu.tamu.app.cache.model.Card;
 import edu.tamu.app.cache.model.Member;
 import edu.tamu.app.cache.model.Sprint;
+import edu.tamu.app.model.ServiceType;
 
 @RunWith(SpringRunner.class)
 public class ActiveSprintsCacheTest {
@@ -62,7 +63,7 @@ public class ActiveSprintsCacheTest {
     private Sprint getMockSprint() {
         List<Member> assignees = Arrays.asList(new Member[] { new Member("1", "Bob Boring", "http://gravatar.com/bborring") });
         List<Card> cards = Arrays.asList(new Card[] { new Card("1", "B-00001", "Feature", "Do the thing", "Do it with these requirements", "In Progress", 1.0f, assignees) });
-        return new Sprint("1", "Sprint 1", "Application", cards);
+        return new Sprint("1", "Sprint 1", "Application", ServiceType.GITHUB_MILESTONE.toString(), cards);
     }
 
 }

--- a/src/test/java/edu/tamu/app/cache/controller/ActiveSprintsCacheControllerTest.java
+++ b/src/test/java/edu/tamu/app/cache/controller/ActiveSprintsCacheControllerTest.java
@@ -23,6 +23,7 @@ import edu.tamu.app.cache.model.Card;
 import edu.tamu.app.cache.model.Member;
 import edu.tamu.app.cache.model.Sprint;
 import edu.tamu.app.cache.service.ActiveSprintsScheduledCacheService;
+import edu.tamu.app.model.ServiceType;
 import edu.tamu.weaver.response.ApiResponse;
 import edu.tamu.weaver.response.ApiStatus;
 
@@ -64,7 +65,7 @@ public class ActiveSprintsCacheControllerTest {
     private Sprint getMockSprint() {
         List<Member> assignees = Arrays.asList(new Member[] { new Member("1", "Bob Boring", "http://gravatar.com/bborring") });
         List<Card> cards = Arrays.asList(new Card[] { new Card("1", "B-00001", "Feature", "Do the thing", "Do it with these requirements", "In Progress", 1.0f, assignees) });
-        return new Sprint("1", "Sprint 1", "Application", cards);
+        return new Sprint("1", "Sprint 1", "Application", ServiceType.GITHUB_MILESTONE.toString(), cards);
     }
 
     private void assertSprints(List<Sprint> sprints) {
@@ -73,6 +74,7 @@ public class ActiveSprintsCacheControllerTest {
         assertEquals("1", sprints.get(0).getId());
         assertEquals("Sprint 1", sprints.get(0).getName());
         assertEquals("Application", sprints.get(0).getProduct());
+        assertEquals(ServiceType.GITHUB_MILESTONE.toString(), sprints.get(0).getType());
         assertFalse(sprints.get(0).getCards().isEmpty());
         assertEquals(1, sprints.get(0).getCards().size());
         assertEquals("1", sprints.get(0).getCards().get(0).getId());

--- a/src/test/java/edu/tamu/app/cache/controller/integration/ActiveSprintsCacheControllerIntegrationTest.java
+++ b/src/test/java/edu/tamu/app/cache/controller/integration/ActiveSprintsCacheControllerIntegrationTest.java
@@ -35,6 +35,7 @@ import edu.tamu.app.cache.model.Sprint;
 import edu.tamu.app.cache.service.ActiveSprintsScheduledCacheService;
 import edu.tamu.app.cache.service.ProductsStatsScheduledCacheService;
 import edu.tamu.app.cache.service.RemoteProjectsScheduledCacheService;
+import edu.tamu.app.model.ServiceType;
 import edu.tamu.app.model.repo.AbstractRepoTest;
 
 @SpringBootTest(classes = { ProductApplication.class }, webEnvironment=WebEnvironment.RANDOM_PORT)
@@ -66,8 +67,9 @@ public class ActiveSprintsCacheControllerIntegrationTest extends AbstractRepoTes
     private static final String TEST_SPRINT_ID = "Test Stat ID";
     private static final String TEST_SPRINT_NAME = "Test Stat Name";
     private static final String TEST_SPRINT_PRODUCT = "Test Sprint Product";
+    private static final String TEST_SPRINT_TYPE = ServiceType.GITHUB_MILESTONE.toString();
 
-    private static final Sprint TEST_SPRINT = new Sprint(TEST_SPRINT_ID, TEST_SPRINT_NAME, TEST_SPRINT_PRODUCT, TEST_CARD_LIST);
+    private static final Sprint TEST_SPRINT = new Sprint(TEST_SPRINT_ID, TEST_SPRINT_NAME, TEST_SPRINT_PRODUCT, TEST_SPRINT_TYPE, TEST_CARD_LIST);
 
     private static final List<Sprint> TEST_SPRINT_LIST = new ArrayList<Sprint>(Arrays.asList(TEST_SPRINT));
 
@@ -119,6 +121,7 @@ public class ActiveSprintsCacheControllerIntegrationTest extends AbstractRepoTes
                         fieldWithPath("payload['ArrayList<Sprint>'][0].id").description("The Sprint ID."),
                         fieldWithPath("payload['ArrayList<Sprint>'][0].name").description("The Sprint Name."),
                         fieldWithPath("payload['ArrayList<Sprint>'][0].product").description("The Sprint Product."),
+                        fieldWithPath("payload['ArrayList<Sprint>'][0].type").description("The Sprint Product's Remote Project Type."),
                         fieldWithPath("payload['ArrayList<Sprint>'][0].cards").description("An array of Sprint Cards."),
                         fieldWithPath("payload['ArrayList<Sprint>'][0].cards[0].id").description("The Sprint Card ID."),
                         fieldWithPath("payload['ArrayList<Sprint>'][0].cards[0].number").description("The Sprint Card Number."),

--- a/src/test/java/edu/tamu/app/cache/model/SprintTest.java
+++ b/src/test/java/edu/tamu/app/cache/model/SprintTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import edu.tamu.app.model.ServiceType;
+
 @RunWith(SpringRunner.class)
 public class SprintTest {
 
@@ -17,10 +19,11 @@ public class SprintTest {
     public void testNewSprint() {
         List<Member> assignees = Arrays.asList(new Member[] { new Member("1", "Bob Boring", "http://gravatar.com/bborring") });
         List<Card> cards = Arrays.asList(new Card[] { new Card("1", "B-00001", "Feature", "Do the thing", "Do it with these requirements", "In Progress", 1.0f, assignees) });
-        Sprint sprint = new Sprint("1", "Sprint 1", "Application", cards);
+        Sprint sprint = new Sprint("1", "Sprint 1", "Application", ServiceType.GITHUB_MILESTONE.toString(), cards);
         assertEquals("1", sprint.getId());
         assertEquals("Sprint 1", sprint.getName());
         assertEquals("Application", sprint.getProduct());
+        assertEquals(ServiceType.GITHUB_MILESTONE.toString(), sprint.getType());
         assertFalse(sprint.getCards().isEmpty());
         assertEquals(1, sprint.getCards().size());
         assertEquals("1", sprint.getCards().get(0).getId());

--- a/src/test/java/edu/tamu/app/cache/service/ActiveSprintsScheduledCacheServiceTest.java
+++ b/src/test/java/edu/tamu/app/cache/service/ActiveSprintsScheduledCacheServiceTest.java
@@ -138,7 +138,7 @@ public class ActiveSprintsScheduledCacheServiceTest {
     private Sprint getMockSprint() {
         List<Member> assignees = Arrays.asList(new Member[] { new Member("1", "Bob Boring", "http://gravatar.com/bborring") });
         List<Card> cards = Arrays.asList(new Card[] { new Card("3000", "B-00001", "Feature", "Do the thing", "Do it with these requirements", "In Progress", 1.0f, assignees) });
-        return new Sprint("2000", "Sprint 1", "Test Product", cards);
+        return new Sprint("2000", "Sprint 1", "Test Product", ServiceType.GITHUB_MILESTONE.toString(), cards);
     }
 
     private void assertSprints(List<Sprint> sprints) {
@@ -147,6 +147,7 @@ public class ActiveSprintsScheduledCacheServiceTest {
         assertEquals("2000", sprints.get(0).getId());
         assertEquals("Sprint 1", sprints.get(0).getName());
         assertEquals("Test Product", sprints.get(0).getProduct());
+        assertEquals(ServiceType.GITHUB_MILESTONE.toString(), sprints.get(0).getType());
         assertFalse(sprints.get(0).getCards().isEmpty());
         assertEquals(1, sprints.get(0).getCards().size());
         assertEquals("3000", sprints.get(0).getCards().get(0).getId());

--- a/src/test/java/edu/tamu/app/service/manager/GitHubMilestoneServiceTest.java
+++ b/src/test/java/edu/tamu/app/service/manager/GitHubMilestoneServiceTest.java
@@ -408,6 +408,24 @@ public class GitHubMilestoneServiceTest extends CacheMockTests {
     }
 
     @Test
+    public void testGetActiveSprintsByProjectIdType() throws Exception {
+        List<Sprint> sprints = gitHubMilestoneService.getActiveSprintsByScopeId(String.valueOf(TEST_REPOSITORY1_ID));
+
+        sprints.forEach(sprint -> {
+            assertEquals("Didn't get the correct Service Type for the Sprint", ServiceType.GITHUB_MILESTONE.toString(), sprint.getType());
+        });
+    }
+
+    @Test
+    public void testGetAdditionalActiveSprintsType() throws Exception {
+        List<Sprint> sprints = gitHubMilestoneService.getAdditionalActiveSprints();
+
+        sprints.forEach(sprint -> {
+            assertEquals("Didn't get the correct Service Type for the Sprint", ServiceType.GITHUB_MILESTONE.toString(), sprint.getType());
+        });
+    }
+
+    @Test
     public void testPush() throws Exception {
         String id = gitHubMilestoneService.push(TEST_FEATURE_REQUEST);
         assertNotNull(id);

--- a/src/test/java/edu/tamu/app/service/manager/GitHubProjectServiceTest.java
+++ b/src/test/java/edu/tamu/app/service/manager/GitHubProjectServiceTest.java
@@ -396,6 +396,24 @@ public class GitHubProjectServiceTest extends CacheMockTests {
     }
 
     @Test
+    public void testGetActiveSprintsByProjectIdType() throws Exception {
+        List<Sprint> sprints = gitHubProjectService.getActiveSprintsByScopeId(String.valueOf(TEST_REPOSITORY1_ID));
+
+        sprints.forEach(sprint -> {
+            assertEquals("Didn't get the correct Service Type for the Sprint", ServiceType.GITHUB_PROJECT.toString(), sprint.getType());
+        });
+    }
+
+    @Test
+    public void testGetAdditionalActiveSprintType() throws Exception {
+        List<Sprint> sprints = gitHubProjectService.getAdditionalActiveSprints();
+
+        sprints.forEach(sprint -> {
+            assertEquals("Didn't get the correct Service Type for the Sprint", ServiceType.GITHUB_PROJECT.toString(), sprint.getType());
+        });
+    }
+
+    @Test
     public void testPush() throws Exception {
         String id = gitHubProjectService.push(TEST_FEATURE_REQUEST);
         assertNotNull(id);

--- a/src/test/resources/mock/cache/active-sprints.json
+++ b/src/test/resources/mock/cache/active-sprints.json
@@ -3,6 +3,7 @@
     "id": "0001",
     "name": "Sprint 1",
     "product": "Test Product 1",
+    "type": "GITHUB_MILESTONE",
     "cards": [
       {
         "id": "0001",
@@ -67,6 +68,7 @@
     "id": "0002",
     "name": "Sprint 2",
     "product": "Test Product 2",
+    "type": "GITHUB_MILESTONE",
     "cards": [
       {
         "id": "0003",


### PR DESCRIPTION
A string is used on the Sprint model instead of the ServiceType object to keep the representation simple and allow to allow the use of an empty string.

relates TAMULib/ProjectManagementUI#87
relates TAMULib/ProjectManagementUI#80