### PR TITLE
[Sprint7] [118] put back the fallback name.

### DIFF
--- a/src/main/java/edu/tamu/app/service/manager/AbstractGitHubService.java
+++ b/src/main/java/edu/tamu/app/service/manager/AbstractGitHubService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.kohsuke.github.GHIssue;
 import org.kohsuke.github.GHIssueState;
@@ -191,7 +192,7 @@ public abstract class AbstractGitHubService extends MappingRemoteProjectManagerB
         if (cachedMember.isPresent()) {
             member = cachedMember.get();
         } else {
-            final String name = user.getName();
+            final String name = StringUtils.isEmpty(user.getName()) ? user.getLogin() : user.getName();
             final String avatarUrlString = user.getAvatarUrl();
             final String avatarPath = getAvatarPath(avatarUrlString);
             member = new Member(memberId, name, avatarPath);


### PR DESCRIPTION
This was lost during the redesign GithubService to support Milestones and Projects changes.

This restores the fix for #118 that was lost during a refactor.