### PR TITLE
Upgrade to Java 11 by bringing in removed artifact.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,18 @@
       <version>1.101</version>
     </dependency>
 
+    <dependency>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+        <version>2.3.3</version>
+    </dependency>
+
+    <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <version>2.3.3</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
These jaxb-api artifact was removed from the default bundle.
This module is still available in java, but as a separate artifact.

If the goal is to make this JDK11+ only, then the following can be added to the pom.xml (under `<properties>`):
```
  <java.version>11</java.version>
  <maven.compiler.release>11</maven.compiler.release>
```

However, it makes more sense to me to omit that as the current changes still work under JDK8.
This means JDK8 is still supported by the changes in this commit.

The jaxb, however, is deprecated or possibly deprecated (see link below).
This means using a more future compatible approach of using `jakarta.xml.bind` and `org.glassfish.jaxb`.

There is also versions 3.0.x of these under new paths:
```
<!-- JAXB API v3.0.1 -->
<dependency>
    <groupId>jakarta.xml.bind</groupId>
    <artifactId>jakarta.xml.bind-api</artifactId>
    <version>3.0.1</version>
</dependency>

<!-- JAXB v3.0.2 reference implementation (curiously with com.sun coordinates) -->
<dependency>
    <groupId>com.sun.xml.bind</groupId>
    <artifactId>jaxb-impl</artifactId>
    <version>3.0.2</version>
    <scope>runtime</scope>
</dependency>
```

These, however, are avoided for now to ensure compatibility between jdk8 and jdk11.

see: https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception/43574427#43574427
see: http://openjdk.java.net/jeps/320
see: https://github.com/spring-projects/spring-boot/issues/11205
see: https://nipafx.dev/java-11-migration-guide/
see: https://jesperdj.com/2018/09/30/jaxb-on-java-9-10-11-and-beyond/