### PR TITLE
Move bytebuddy into a profile.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           java-version: 11
 
       - name: "Maven Test"
-        run: mvn clean test jacoco:report coveralls:report -DdryRun=true
+        run: mvn clean test jacoco:report coveralls:report -DdryRun=true -Pbuddy
 
       - name: "Send to Coveralls (build java-${{ github.run_number }})"
         uses: MikeEdgar/github-action@raw_coverage_file

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,24 @@
         <maven.packaging>jar</maven.packaging>
       </properties>
     </profile>
+    <profile>
+      <id>buddy</id>
+      <dependencies>
+        <dependency>
+          <groupId>net.bytebuddy</groupId>
+          <artifactId>byte-buddy</artifactId>
+          <version>1.12.13</version>
+          <scope>test</scope>
+        </dependency>
+
+        <dependency>
+          <groupId>net.bytebuddy</groupId>
+          <artifactId>byte-buddy-agent</artifactId>
+          <version>1.12.13</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <dependencies>
@@ -148,20 +166,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <version>4.6.1</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy</artifactId>
-      <version>1.12.13</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy-agent</artifactId>
-      <version>1.12.13</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Possibly solution or work-around by moving the byte buddy version into a profile.

Spring doesn't support the byte buddy version needed by tests.
Move bytebuddy into a special profile.
This byte buddy version is required for testing to avoid flaws or bugs in the byte buddy version.